### PR TITLE
Implement M6: Generation engine with KV cache

### DIFF
--- a/src/engine/embed.rs
+++ b/src/engine/embed.rs
@@ -367,6 +367,7 @@ mod tests {
             layers: vec![layer],
             output_norm_w: ones_weight(h),
             output_norm_b: None,
+            output_projection: None,
         }
     }
 

--- a/src/engine/generate.rs
+++ b/src/engine/generate.rs
@@ -1,0 +1,796 @@
+//! Generation engine: prompt → text via autoregressive decoding.
+//!
+//! [`GenerationEngine`] provides a high-level API for text generation from
+//! any supported causal GGUF model (Gemma, LLaMA, etc.) using a KV cache
+//! for efficient token-by-token decoding.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tracing::{debug, info};
+
+use crate::backend::{ComputeBackend, DeviceTensor};
+use crate::error::InferenceError;
+use crate::gguf::GgufFile;
+use crate::model::cache::KvCache;
+use crate::model::config::ModelConfig;
+use crate::model::layer::{linear_forward, model_forward_step};
+use crate::model::weights::ModelWeights;
+use crate::tensor::Tensor;
+use crate::tokenizer::{create_tokenizer_from_gguf, Tokenizer};
+
+use super::sampler::{SamplingConfig, XorShiftRng, sample_token};
+
+/// Configuration for text generation.
+#[derive(Debug, Clone)]
+pub struct GenerationConfig {
+    /// Maximum number of tokens to generate (excluding the prompt).
+    pub max_tokens: usize,
+    /// Stop generation when any of these token IDs are produced.
+    pub stop_tokens: Vec<u32>,
+    /// Sampling parameters (temperature, top-k, top-p).
+    pub sampling: SamplingConfig,
+}
+
+impl Default for GenerationConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens: 256,
+            stop_tokens: Vec::new(),
+            sampling: SamplingConfig::default(),
+        }
+    }
+}
+
+/// High-level generation engine for autoregressive text generation.
+///
+/// Wraps a GGUF model with its tokenizer, compute backend, and KV cache
+/// to provide `generate(prompt) -> String` and streaming APIs.
+pub struct GenerationEngine {
+    config: ModelConfig,
+    weights: ModelWeights,
+    tokenizer: Box<dyn Tokenizer>,
+    backend: Arc<dyn ComputeBackend>,
+}
+
+impl GenerationEngine {
+    /// Load a generation engine from a GGUF file path.
+    ///
+    /// Validates that the model is causal (generation doesn't make sense
+    /// for bidirectional models like BERT).
+    pub fn from_gguf(
+        path: impl AsRef<Path>,
+        backend: Arc<dyn ComputeBackend>,
+    ) -> Result<Self, InferenceError> {
+        let path = path.as_ref();
+        info!(path = %path.display(), "Loading generation engine from GGUF");
+        let gguf = GgufFile::open(path)?;
+        let config = ModelConfig::from_gguf(&gguf)?;
+
+        if !config.causal {
+            return Err(InferenceError::Generation(
+                "generation requires a causal model (not bidirectional)".to_string(),
+            ));
+        }
+
+        let weights = ModelWeights::from_gguf(&gguf, &config, backend.as_ref())?;
+        let tokenizer = create_tokenizer_from_gguf(&gguf)?;
+
+        info!(
+            arch = %config.arch_name,
+            hidden_size = config.hidden_size,
+            vocab_size = config.vocab_size,
+            max_seq_len = config.max_seq_len,
+            "Generation engine loaded"
+        );
+
+        Ok(Self {
+            config,
+            weights,
+            tokenizer,
+            backend,
+        })
+    }
+
+    /// Crate-internal constructor for testing with synthetic components.
+    #[cfg(test)]
+    pub(crate) fn new(
+        config: ModelConfig,
+        weights: ModelWeights,
+        tokenizer: Box<dyn Tokenizer>,
+        backend: Arc<dyn ComputeBackend>,
+    ) -> Self {
+        Self {
+            config,
+            weights,
+            tokenizer,
+            backend,
+        }
+    }
+
+    /// Generate text from a prompt.
+    ///
+    /// Steps:
+    /// 1. Tokenize the prompt
+    /// 2. Validate prompt length
+    /// 3. Create KV cache
+    /// 4. Prefill: run all prompt tokens through the model
+    /// 5. Sample first token from prefill output
+    /// 6. Decode loop: generate tokens one at a time until stop condition
+    /// 7. Decode generated token IDs to text
+    pub fn generate(
+        &self,
+        prompt: &str,
+        gen_config: &GenerationConfig,
+    ) -> Result<String, InferenceError> {
+        if !self.config.causal {
+            return Err(InferenceError::Generation(
+                "generation requires a causal model (not bidirectional)".to_string(),
+            ));
+        }
+
+        let prompt_ids = self.tokenizer.encode(prompt, true);
+
+        if prompt_ids.is_empty() {
+            return Err(InferenceError::Generation(
+                "prompt tokenized to empty sequence".to_string(),
+            ));
+        }
+
+        if prompt_ids.len() >= self.config.max_seq_len {
+            return Err(InferenceError::Generation(format!(
+                "prompt length ({}) exceeds max_seq_len ({})",
+                prompt_ids.len(),
+                self.config.max_seq_len
+            )));
+        }
+
+        let mut rng = XorShiftRng::new(gen_config.sampling.seed.unwrap_or(42));
+        let mut cache = KvCache::new(&self.config);
+        let mut generated_ids: Vec<u32> = Vec::new();
+
+        // Collect all stop tokens (explicit + EOS)
+        let mut stop_tokens = gen_config.stop_tokens.clone();
+        if let Some(eos) = self.tokenizer.eos_token_id() {
+            if !stop_tokens.contains(&eos) {
+                stop_tokens.push(eos);
+            }
+        }
+
+        // Prefill: process all prompt tokens at once
+        let hidden = model_forward_step(
+            &prompt_ids,
+            &self.weights,
+            &self.config,
+            self.backend.as_ref(),
+            &mut cache,
+        )?;
+
+        // Project last hidden state to logits and sample first token
+        let logits = self.project_to_logits(&hidden, prompt_ids.len() - 1);
+        let mut next_token = sample_token(&logits, &gen_config.sampling, &mut rng);
+
+        debug!(first_token = next_token, "Prefill complete, starting decode");
+
+        // Decode loop
+        for step in 0..gen_config.max_tokens {
+            // Check stop conditions
+            if stop_tokens.contains(&next_token) {
+                debug!(step, token = next_token, "Stop token encountered");
+                break;
+            }
+
+            if cache.len() >= self.config.max_seq_len {
+                debug!(step, "Context length reached");
+                break;
+            }
+
+            generated_ids.push(next_token);
+
+            // Forward pass with single token
+            let hidden = model_forward_step(
+                &[next_token],
+                &self.weights,
+                &self.config,
+                self.backend.as_ref(),
+                &mut cache,
+            )?;
+
+            // Project to logits and sample
+            let logits = self.project_to_logits(&hidden, 0);
+            next_token = sample_token(&logits, &gen_config.sampling, &mut rng);
+        }
+
+        // Decode generated token IDs to text
+        Ok(self.tokenizer.decode(&generated_ids))
+    }
+
+    /// Generate text with streaming: invokes callback for each generated token.
+    ///
+    /// The callback receives each token ID as it's generated. Return `false`
+    /// from the callback to stop generation early.
+    pub fn generate_stream(
+        &self,
+        prompt: &str,
+        gen_config: &GenerationConfig,
+        mut callback: impl FnMut(u32) -> bool,
+    ) -> Result<Vec<u32>, InferenceError> {
+        if !self.config.causal {
+            return Err(InferenceError::Generation(
+                "generation requires a causal model (not bidirectional)".to_string(),
+            ));
+        }
+
+        let prompt_ids = self.tokenizer.encode(prompt, true);
+
+        if prompt_ids.is_empty() {
+            return Err(InferenceError::Generation(
+                "prompt tokenized to empty sequence".to_string(),
+            ));
+        }
+
+        if prompt_ids.len() >= self.config.max_seq_len {
+            return Err(InferenceError::Generation(format!(
+                "prompt length ({}) exceeds max_seq_len ({})",
+                prompt_ids.len(),
+                self.config.max_seq_len
+            )));
+        }
+
+        let mut rng = XorShiftRng::new(gen_config.sampling.seed.unwrap_or(42));
+        let mut cache = KvCache::new(&self.config);
+        let mut generated_ids: Vec<u32> = Vec::new();
+
+        let mut stop_tokens = gen_config.stop_tokens.clone();
+        if let Some(eos) = self.tokenizer.eos_token_id() {
+            if !stop_tokens.contains(&eos) {
+                stop_tokens.push(eos);
+            }
+        }
+
+        // Prefill
+        let hidden = model_forward_step(
+            &prompt_ids,
+            &self.weights,
+            &self.config,
+            self.backend.as_ref(),
+            &mut cache,
+        )?;
+
+        let logits = self.project_to_logits(&hidden, prompt_ids.len() - 1);
+        let mut next_token = sample_token(&logits, &gen_config.sampling, &mut rng);
+
+        // Decode loop
+        for _ in 0..gen_config.max_tokens {
+            if stop_tokens.contains(&next_token) {
+                break;
+            }
+
+            if cache.len() >= self.config.max_seq_len {
+                break;
+            }
+
+            generated_ids.push(next_token);
+
+            if !callback(next_token) {
+                break;
+            }
+
+            let hidden = model_forward_step(
+                &[next_token],
+                &self.weights,
+                &self.config,
+                self.backend.as_ref(),
+                &mut cache,
+            )?;
+
+            let logits = self.project_to_logits(&hidden, 0);
+            next_token = sample_token(&logits, &gen_config.sampling, &mut rng);
+        }
+
+        Ok(generated_ids)
+    }
+
+    /// Project a hidden state row to vocabulary logits.
+    ///
+    /// Uses `output_projection` weight if available, otherwise falls back to
+    /// tied embeddings (`token_embedding`).
+    fn project_to_logits(&self, hidden: &DeviceTensor, row: usize) -> Vec<f32> {
+        let hidden_size = self.config.hidden_size;
+        let hidden_data = hidden.tensor.as_f32();
+        let start = row * hidden_size;
+        let row_data = &hidden_data[start..start + hidden_size];
+
+        let row_tensor = DeviceTensor::new(
+            Tensor::new(vec![1, hidden_size], row_data.to_vec()),
+        );
+
+        // Use output_projection if available, otherwise tied embeddings
+        let proj_weight = self.weights.output_projection.as_ref()
+            .unwrap_or(&self.weights.token_embedding);
+
+        let logits_tensor = linear_forward(&row_tensor, proj_weight, None, self.backend.as_ref());
+        logits_tensor.tensor.as_f32().to_vec()
+    }
+
+    /// The model configuration.
+    pub fn config(&self) -> &ModelConfig {
+        &self.config
+    }
+
+    /// The vocabulary size of the loaded model.
+    pub fn vocab_size(&self) -> usize {
+        self.config.vocab_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::cpu::CpuBackend;
+    use crate::backend::DeviceTensor;
+    use crate::model::config::*;
+    use crate::model::weights::{LayerWeights, ModelWeights};
+    use crate::tensor::Tensor;
+    use crate::tokenizer::Tokenizer;
+
+    /// A mock tokenizer for generation tests.
+    ///
+    /// Maps token IDs to single-character strings for easy verification.
+    struct MockTokenizer {
+        vocab: Vec<String>,
+        eos_id: u32,
+    }
+
+    impl MockTokenizer {
+        fn new() -> Self {
+            Self {
+                vocab: vec![
+                    "<pad>".to_string(),  // 0
+                    "<bos>".to_string(),  // 1
+                    "<eos>".to_string(),  // 2
+                    "hello".to_string(),  // 3
+                    "world".to_string(),  // 4
+                    "foo".to_string(),    // 5
+                    "bar".to_string(),    // 6
+                    "baz".to_string(),    // 7
+                ],
+                eos_id: 2,
+            }
+        }
+    }
+
+    impl Tokenizer for MockTokenizer {
+        fn encode(&self, text: &str, add_special_tokens: bool) -> Vec<u32> {
+            let mut ids = Vec::new();
+            if add_special_tokens {
+                ids.push(1); // BOS
+            }
+            for word in text.split_whitespace() {
+                let id = self
+                    .vocab
+                    .iter()
+                    .position(|v| v == word)
+                    .map(|i| i as u32)
+                    .unwrap_or(0);
+                ids.push(id);
+            }
+            // Note: no EOS added for generation (model generates EOS)
+            ids
+        }
+
+        fn decode(&self, ids: &[u32]) -> String {
+            ids.iter()
+                .filter_map(|&id| self.vocab.get(id as usize))
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(" ")
+        }
+
+        fn vocab_size(&self) -> usize {
+            self.vocab.len()
+        }
+
+        fn bos_token_id(&self) -> Option<u32> {
+            Some(1)
+        }
+
+        fn eos_token_id(&self) -> Option<u32> {
+            Some(self.eos_id)
+        }
+
+        fn pad_token_id(&self) -> Option<u32> {
+            Some(0)
+        }
+    }
+
+    /// A mock tokenizer with no EOS token, for testing max_tokens without
+    /// EOS interference.
+    struct NoEosTokenizer;
+
+    impl NoEosTokenizer {
+        fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Tokenizer for NoEosTokenizer {
+        fn encode(&self, text: &str, add_special_tokens: bool) -> Vec<u32> {
+            let mut ids = Vec::new();
+            if add_special_tokens {
+                ids.push(1); // BOS
+            }
+            for word in text.split_whitespace() {
+                // Simple hash to token ID (3-7 range, avoiding 0-2)
+                let id = 3 + (word.len() as u32 % 5);
+                ids.push(id);
+            }
+            ids
+        }
+
+        fn decode(&self, ids: &[u32]) -> String {
+            ids.iter().map(|id| format!("t{}", id)).collect::<Vec<_>>().join(" ")
+        }
+
+        fn vocab_size(&self) -> usize { 8 }
+        fn bos_token_id(&self) -> Option<u32> { Some(1) }
+        fn eos_token_id(&self) -> Option<u32> { None } // No EOS
+        fn pad_token_id(&self) -> Option<u32> { Some(0) }
+    }
+
+    fn dt(tensor: Tensor) -> DeviceTensor {
+        DeviceTensor::new(tensor)
+    }
+
+    fn identity_weight(size: usize) -> DeviceTensor {
+        let mut data = vec![0.0f32; size * size];
+        for i in 0..size {
+            data[i * size + i] = 1.0;
+        }
+        dt(Tensor::new(vec![size, size], data))
+    }
+
+    fn zero_weight(out_dim: usize, in_dim: usize) -> DeviceTensor {
+        dt(Tensor::new(
+            vec![out_dim, in_dim],
+            vec![0.0f32; out_dim * in_dim],
+        ))
+    }
+
+    fn ones_weight(dim: usize) -> DeviceTensor {
+        dt(Tensor::new(vec![dim], vec![1.0f32; dim]))
+    }
+
+    /// Build a causal Gemma-style config for generation tests.
+    fn gen_config(hidden_size: usize) -> ModelConfig {
+        ModelConfig {
+            arch: ModelArch::Gemma3,
+            arch_name: "gemma3".to_string(),
+            hidden_size,
+            num_layers: 1,
+            num_heads: 1,
+            num_kv_heads: 1,
+            head_dim: hidden_size,
+            ffn_hidden: hidden_size * 4,
+            vocab_size: 8,
+            max_seq_len: 64,
+            norm_type: NormType::RMSNorm,
+            norm_eps: 1e-6,
+            activation: Activation::SwiGLU,
+            position_type: PositionType::RoPE,
+            rope_freq_base: 10000.0,
+            rope_dim: hidden_size,
+            causal: true,
+            attn_logit_softcap: 0.0,
+            attn_scale: None,
+            embedding_scale: 1.0,
+            pooling_type: PoolingType::None,
+            has_ffn_gate: true,
+            has_bias: false,
+            pre_norm: true,
+        }
+    }
+
+    fn gen_weights(config: &ModelConfig) -> ModelWeights {
+        let h = config.hidden_size;
+        let ffn = config.ffn_hidden;
+        let v = config.vocab_size;
+
+        // Use distinct embedding rows
+        let mut emb_data = vec![0.0f32; v * h];
+        for i in 0..v {
+            for j in 0..h {
+                emb_data[i * h + j] = ((i * h + j) as f32) * 0.1;
+            }
+        }
+
+        let layer = LayerWeights {
+            attn_norm_w: Some(ones_weight(h)),
+            attn_norm_b: None,
+            ffn_norm_w: Some(ones_weight(h)),
+            ffn_norm_b: None,
+            attn_output_norm_w: None,
+            attn_output_norm_b: None,
+            ffn_output_norm_w: None,
+            ffn_output_norm_b: None,
+            attn_q: identity_weight(h),
+            attn_k: identity_weight(h),
+            attn_v: identity_weight(h),
+            attn_output: identity_weight(h),
+            attn_q_bias: None,
+            attn_k_bias: None,
+            attn_v_bias: None,
+            attn_output_bias: None,
+            ffn_up: zero_weight(ffn, h),
+            ffn_down: zero_weight(h, ffn),
+            ffn_gate: Some(zero_weight(ffn, h)),
+            ffn_up_bias: None,
+            ffn_down_bias: None,
+        };
+
+        ModelWeights {
+            token_embedding: dt(Tensor::new(vec![v, h], emb_data)),
+            position_embedding: None,
+            embedding_norm_w: None,
+            embedding_norm_b: None,
+            layers: vec![layer],
+            output_norm_w: ones_weight(h),
+            output_norm_b: None,
+            output_projection: None, // tied embeddings
+        }
+    }
+
+    fn build_gen_engine(config: ModelConfig) -> GenerationEngine {
+        let weights = gen_weights(&config);
+        let tokenizer: Box<dyn Tokenizer> = Box::new(MockTokenizer::new());
+        let backend: Arc<dyn ComputeBackend> = Arc::new(CpuBackend::new());
+        GenerationEngine::new(config, weights, tokenizer, backend)
+    }
+
+    #[test]
+    fn test_generate_greedy_deterministic() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig {
+            max_tokens: 5,
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result1 = engine.generate("hello", &gen_cfg).unwrap();
+        let result2 = engine.generate("hello", &gen_cfg).unwrap();
+        assert_eq!(result1, result2, "Greedy generation should be deterministic");
+    }
+
+    #[test]
+    fn test_generate_stops_at_max_tokens() {
+        // Use a tokenizer with no EOS to isolate max_tokens behavior
+        let config = gen_config(4);
+        let weights = gen_weights(&config);
+        let tokenizer: Box<dyn Tokenizer> = Box::new(NoEosTokenizer::new());
+        let backend: Arc<dyn ComputeBackend> = Arc::new(CpuBackend::new());
+        let engine = GenerationEngine::new(config, weights, tokenizer, backend);
+
+        let gen_cfg = GenerationConfig {
+            max_tokens: 3,
+            stop_tokens: vec![],
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+        };
+
+        // Use generate_stream to count exact tokens produced
+        let mut token_count = 0;
+        let result = engine.generate_stream("hello", &gen_cfg, |_| {
+            token_count += 1;
+            true
+        });
+        assert!(result.is_ok());
+        let generated = result.unwrap();
+        assert!(
+            generated.len() <= 3,
+            "Expected at most 3 tokens, got {}",
+            generated.len()
+        );
+        assert_eq!(generated.len(), token_count);
+    }
+
+    #[test]
+    fn test_generate_stops_at_eos() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+
+        // Use a large max_tokens — if EOS stops generation, we'll get
+        // far fewer tokens than the limit.
+        let gen_cfg = GenerationConfig {
+            max_tokens: 100,
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Count tokens via stream to verify EOS stops before max_tokens
+        let mut token_count = 0;
+        let result = engine.generate_stream("hello", &gen_cfg, |_| {
+            token_count += 1;
+            true
+        });
+        assert!(result.is_ok());
+        let generated = result.unwrap();
+        // With EOS in the vocabulary (token 2), generation should stop
+        // well before 100 tokens. Verify it stopped early.
+        assert!(
+            generated.len() < 100,
+            "Expected EOS to stop generation before 100 tokens, got {}",
+            generated.len()
+        );
+    }
+
+    #[test]
+    fn test_generate_stream_callback() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig {
+            max_tokens: 10,
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut received_tokens = Vec::new();
+        let result = engine.generate_stream("hello", &gen_cfg, |token_id| {
+            received_tokens.push(token_id);
+            received_tokens.len() < 3 // stop after 3 tokens
+        });
+
+        assert!(result.is_ok());
+        let generated = result.unwrap();
+        // Should have stopped at 3 or fewer tokens
+        assert!(generated.len() <= 3);
+        assert_eq!(generated.len(), received_tokens.len());
+        // Verify callback received exactly the same token IDs as the result
+        assert_eq!(
+            generated, received_tokens,
+            "Stream callback tokens should match returned tokens"
+        );
+    }
+
+    #[test]
+    fn test_generate_rejects_non_causal_model() {
+        let mut config = gen_config(4);
+        config.causal = false;
+        config.arch = ModelArch::Bert;
+
+        let weights = gen_weights(&config);
+        let tokenizer: Box<dyn Tokenizer> = Box::new(MockTokenizer::new());
+        let backend: Arc<dyn ComputeBackend> = Arc::new(CpuBackend::new());
+        let engine = GenerationEngine::new(config, weights, tokenizer, backend);
+
+        let gen_cfg = GenerationConfig::default();
+        let result = engine.generate("hello", &gen_cfg);
+        assert!(result.is_err(), "generate() should reject non-causal model");
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("causal"), "Error should mention causal: {}", err_msg);
+
+        // Also test generate_stream rejects non-causal
+        let stream_result = engine.generate_stream("hello", &gen_cfg, |_| true);
+        assert!(stream_result.is_err(), "generate_stream() should reject non-causal model");
+    }
+
+    #[test]
+    fn test_generate_empty_prompt() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig::default();
+
+        // Empty string still gets BOS from mock tokenizer, so it's 1 token
+        let result = engine.generate("", &gen_cfg);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_generate_prompt_exceeds_context() {
+        let mut config = gen_config(4);
+        config.max_seq_len = 3; // very short
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig::default();
+
+        // "hello world foo" with BOS = 4 tokens, exceeds max_seq_len=3
+        let result = engine.generate("hello world foo", &gen_cfg);
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("exceeds max_seq_len"), "Error: {}", err_msg);
+    }
+
+    #[test]
+    fn test_generate_with_explicit_stop_tokens() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig {
+            max_tokens: 100,
+            stop_tokens: vec![3, 4, 5, 6, 7], // stop on any content token
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+        };
+
+        let result = engine.generate("hello", &gen_cfg);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_generate_accessors() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        assert_eq!(engine.vocab_size(), 8);
+        assert_eq!(engine.config().arch, ModelArch::Gemma3);
+        assert!(engine.config().causal);
+    }
+
+    #[test]
+    fn test_generation_engine_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<GenerationEngine>();
+    }
+
+    #[test]
+    fn test_generate_max_tokens_zero() {
+        let config = gen_config(4);
+        let engine = build_gen_engine(config);
+        let gen_cfg = GenerationConfig {
+            max_tokens: 0,
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result = engine.generate("hello", &gen_cfg).unwrap();
+        // max_tokens=0 means no decode steps, so output should be empty
+        assert!(result.is_empty(), "max_tokens=0 should produce empty output, got: {:?}", result);
+    }
+
+    #[test]
+    fn test_generate_and_stream_consistency() {
+        // generate() and generate_stream() should produce the same tokens
+        // for the same input with the same seed.
+        let config = gen_config(4);
+
+        // Build two engines with identical state
+        let engine1 = build_gen_engine(config.clone());
+        let engine2 = build_gen_engine(config);
+
+        let gen_cfg = GenerationConfig {
+            max_tokens: 5,
+            sampling: SamplingConfig {
+                temperature: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // generate() returns decoded text
+        let text_result = engine1.generate("hello", &gen_cfg).unwrap();
+
+        // generate_stream() returns token IDs
+        let stream_ids = engine2.generate_stream("hello", &gen_cfg, |_| true).unwrap();
+
+        // Decode stream IDs using a MockTokenizer (same as used internally)
+        let mock_tok = MockTokenizer::new();
+        let stream_text = mock_tok.decode(&stream_ids);
+        assert_eq!(
+            text_result, stream_text,
+            "generate() and generate_stream() should produce identical output"
+        );
+    }
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,11 +1,14 @@
 //! High-level inference APIs.
 //!
 //! - [`EmbeddingEngine`]: text → dense vector embedding (M5)
-//! - Generation engine: prompt → text (M6, future)
+//! - [`GenerationEngine`]: prompt → text via autoregressive decoding (M6)
 
 pub mod embed;
+pub mod generate;
+pub mod sampler;
 
 pub use embed::EmbeddingEngine;
+pub use generate::GenerationEngine;
 
 #[cfg(test)]
 mod tests {
@@ -59,30 +62,42 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // M6: GenerationEngine (stretch goal)
+    // M6: GenerationEngine integration tests
+    //
+    // These require a real causal GGUF model file (e.g., Gemma, LLaMA).
+    // Unit tests for GenerationEngine are in generate.rs.
     // ------------------------------------------------------------------
 
     #[test]
     #[ignore]
     fn test_generation_engine_greedy_decode() {
-        todo!("Implement greedy generation (M6)");
+        // End-to-end: load real GGUF, generate with greedy decoding,
+        // verify output is deterministic and coherent.
+        //
+        //   let engine = GenerationEngine::from_gguf("model.gguf", backend).unwrap();
+        //   let result = engine.generate("Once upon a time", &gen_config).unwrap();
+        //   assert!(!result.is_empty());
+        todo!("Requires real causal GGUF model file");
     }
 
     #[test]
     #[ignore]
     fn test_generation_engine_max_tokens() {
-        todo!("Implement max_tokens limit (M6)");
+        // Verify max_tokens limit is respected with real model.
+        todo!("Requires real causal GGUF model file");
     }
 
     #[test]
     #[ignore]
     fn test_generation_engine_stop_at_eos() {
-        todo!("Implement EOS stopping (M6)");
+        // Verify EOS stopping with real model.
+        todo!("Requires real causal GGUF model file");
     }
 
     #[test]
     #[ignore]
-    fn test_generation_engine_kv_cache() {
-        todo!("Implement KV cache test (M6)");
+    fn test_generation_engine_kv_cache_consistency() {
+        // Verify KV cache produces same results as full recomputation.
+        todo!("Requires real causal GGUF model file");
     }
 }

--- a/src/engine/sampler.rs
+++ b/src/engine/sampler.rs
@@ -1,0 +1,326 @@
+// M6: Token sampling for autoregressive generation.
+//
+// Provides greedy (argmax) and stochastic sampling with temperature,
+// top-k, and top-p (nucleus) filtering. Uses a simple XorShift RNG
+// to avoid adding the `rand` crate dependency.
+
+/// Sampling configuration for text generation.
+#[derive(Debug, Clone)]
+pub struct SamplingConfig {
+    /// Temperature for logit scaling. 0.0 = greedy (argmax).
+    pub temperature: f32,
+    /// Top-K: keep only the top-k highest probability tokens. 0 = disabled.
+    pub top_k: usize,
+    /// Top-P (nucleus): cumulative probability cutoff. 1.0 = disabled.
+    pub top_p: f32,
+    /// Random seed for reproducibility.
+    pub seed: Option<u64>,
+}
+
+impl Default for SamplingConfig {
+    fn default() -> Self {
+        Self {
+            temperature: 0.0,
+            top_k: 0,
+            top_p: 1.0,
+            seed: None,
+        }
+    }
+}
+
+/// Simple XorShift64 RNG to avoid adding the `rand` crate dependency.
+pub struct XorShiftRng {
+    state: u64,
+}
+
+impl XorShiftRng {
+    /// Create a new RNG from a seed. Seed of 0 is adjusted to 1.
+    pub fn new(seed: u64) -> Self {
+        Self {
+            state: if seed == 0 { 1 } else { seed },
+        }
+    }
+
+    /// Generate the next u64 value.
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    /// Generate a random f32 in [0, 1).
+    pub fn next_f32(&mut self) -> f32 {
+        (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32
+    }
+}
+
+/// Return the index of the maximum value in the logits.
+pub fn argmax(logits: &[f32]) -> u32 {
+    let mut best_idx = 0u32;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &v) in logits.iter().enumerate() {
+        if v > best_val {
+            best_val = v;
+            best_idx = i as u32;
+        }
+    }
+    best_idx
+}
+
+/// Sample a token from logits using the given configuration.
+///
+/// Steps:
+/// 1. If temperature == 0.0, return argmax (greedy).
+/// 2. Apply temperature scaling: logit / temperature.
+/// 3. Top-K: sort, keep top-k candidates.
+/// 4. Softmax over remaining candidates.
+/// 5. Top-P: cumulative probability cutoff, renormalize.
+/// 6. Sample from categorical distribution.
+pub fn sample_token(logits: &[f32], config: &SamplingConfig, rng: &mut XorShiftRng) -> u32 {
+    if logits.is_empty() {
+        return 0;
+    }
+
+    // Greedy
+    if config.temperature <= 0.0 {
+        return argmax(logits);
+    }
+
+    // Build (index, logit) candidates
+    let mut candidates: Vec<(u32, f32)> = logits
+        .iter()
+        .enumerate()
+        .map(|(i, &l)| (i as u32, l / config.temperature))
+        .collect();
+
+    // Top-K: sort by logit descending, keep top_k
+    if config.top_k > 0 && config.top_k < candidates.len() {
+        candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.truncate(config.top_k);
+    }
+
+    // Softmax over candidates
+    let max_logit = candidates.iter().map(|c| c.1).fold(f32::NEG_INFINITY, f32::max);
+    let mut probs: Vec<(u32, f32)> = candidates
+        .iter()
+        .map(|&(idx, logit)| (idx, (logit - max_logit).exp()))
+        .collect();
+    let sum: f32 = probs.iter().map(|c| c.1).sum();
+    for c in &mut probs {
+        c.1 /= sum;
+    }
+
+    // Top-P (nucleus): sort by probability descending, cumulative cutoff
+    if config.top_p < 1.0 {
+        probs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let mut cumulative = 0.0f32;
+        let mut cutoff_idx = probs.len();
+        for (i, &(_, p)) in probs.iter().enumerate() {
+            cumulative += p;
+            if cumulative >= config.top_p {
+                cutoff_idx = i + 1;
+                break;
+            }
+        }
+        probs.truncate(cutoff_idx);
+
+        // Renormalize
+        let sum2: f32 = probs.iter().map(|c| c.1).sum();
+        for c in &mut probs {
+            c.1 /= sum2;
+        }
+    }
+
+    // Sample from categorical distribution
+    let r = rng.next_f32();
+    let mut cumulative = 0.0f32;
+    for &(idx, p) in &probs {
+        cumulative += p;
+        if r < cumulative {
+            return idx;
+        }
+    }
+
+    // Fallback: return last candidate
+    probs.last().map(|c| c.0).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_argmax_basic() {
+        assert_eq!(argmax(&[1.0, 3.0, 2.0]), 1);
+        assert_eq!(argmax(&[5.0, 1.0, 2.0]), 0);
+        assert_eq!(argmax(&[1.0, 2.0, 5.0]), 2);
+    }
+
+    #[test]
+    fn test_argmax_negative() {
+        assert_eq!(argmax(&[-3.0, -1.0, -2.0]), 1);
+    }
+
+    #[test]
+    fn test_argmax_single() {
+        assert_eq!(argmax(&[42.0]), 0);
+    }
+
+    #[test]
+    fn test_greedy_sampling() {
+        let logits = vec![1.0, 5.0, 2.0, 3.0];
+        let config = SamplingConfig {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let mut rng = XorShiftRng::new(42);
+        assert_eq!(sample_token(&logits, &config, &mut rng), 1);
+    }
+
+    #[test]
+    fn test_greedy_deterministic() {
+        let logits = vec![1.0, 5.0, 2.0, 3.0];
+        let config = SamplingConfig {
+            temperature: 0.0,
+            ..Default::default()
+        };
+        let mut rng1 = XorShiftRng::new(42);
+        let mut rng2 = XorShiftRng::new(99);
+        // Greedy ignores RNG
+        assert_eq!(
+            sample_token(&logits, &config, &mut rng1),
+            sample_token(&logits, &config, &mut rng2)
+        );
+    }
+
+    #[test]
+    fn test_temperature_sampling_deterministic_with_seed() {
+        let logits = vec![1.0, 5.0, 2.0, 3.0];
+        let config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 0,
+            top_p: 1.0,
+            seed: Some(42),
+        };
+
+        let mut rng1 = XorShiftRng::new(42);
+        let mut rng2 = XorShiftRng::new(42);
+
+        let t1 = sample_token(&logits, &config, &mut rng1);
+        let t2 = sample_token(&logits, &config, &mut rng2);
+        assert_eq!(t1, t2, "Same seed should produce same token");
+    }
+
+    #[test]
+    fn test_top_k_limits_candidates() {
+        // With top_k=1, it should always pick the highest logit
+        let logits = vec![1.0, 10.0, 2.0, 3.0];
+        let config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 1,
+            top_p: 1.0,
+            seed: None,
+        };
+        let mut rng = XorShiftRng::new(42);
+        // top_k=1 means only the top token is kept
+        assert_eq!(sample_token(&logits, &config, &mut rng), 1);
+    }
+
+    #[test]
+    fn test_top_p_limits_candidates() {
+        // Very low top_p should select only the highest-probability token
+        let logits = vec![0.0, 100.0, 0.0, 0.0];
+        let config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 0,
+            top_p: 0.01,
+            seed: None,
+        };
+        let mut rng = XorShiftRng::new(42);
+        assert_eq!(sample_token(&logits, &config, &mut rng), 1);
+    }
+
+    #[test]
+    fn test_temperature_affects_distribution() {
+        // Very high temperature should make distribution more uniform
+        // Very low temperature should make it more peaked
+        let logits = vec![1.0, 2.0, 3.0, 4.0];
+
+        // Low temperature: should almost always pick highest
+        let config_low = SamplingConfig {
+            temperature: 0.01,
+            top_k: 0,
+            top_p: 1.0,
+            seed: Some(42),
+        };
+        let mut rng = XorShiftRng::new(42);
+        let mut count_top = 0;
+        for _ in 0..100 {
+            if sample_token(&logits, &config_low, &mut rng) == 3 {
+                count_top += 1;
+            }
+        }
+        assert!(count_top > 90, "Low temp should favor top token, got {}/100", count_top);
+    }
+
+    #[test]
+    fn test_combined_top_k_top_p() {
+        let logits = vec![1.0, 10.0, 9.0, 0.0];
+        let config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 2,
+            top_p: 0.5,
+            seed: None,
+        };
+        let mut rng = XorShiftRng::new(42);
+        // top_k=2 keeps indices 1,2 (logits 10,9)
+        // top_p=0.5 further limits; token 1 has ~73% probability, so it alone exceeds 0.5
+        let token = sample_token(&logits, &config, &mut rng);
+        assert!(token == 1 || token == 2, "Should only pick from top-2, got {}", token);
+    }
+
+    #[test]
+    fn test_xorshift_rng_produces_different_values() {
+        let mut rng = XorShiftRng::new(42);
+        let a = rng.next_u64();
+        let b = rng.next_u64();
+        let c = rng.next_u64();
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn test_xorshift_rng_f32_range() {
+        let mut rng = XorShiftRng::new(42);
+        for _ in 0..1000 {
+            let v = rng.next_f32();
+            assert!(v >= 0.0 && v < 1.0, "next_f32 out of range: {}", v);
+        }
+    }
+
+    #[test]
+    fn test_empty_logits() {
+        let config = SamplingConfig::default();
+        let mut rng = XorShiftRng::new(42);
+        assert_eq!(sample_token(&[], &config, &mut rng), 0);
+    }
+
+    #[test]
+    fn test_sampling_returns_valid_index() {
+        let logits = vec![1.0; 100];
+        let config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 0,
+            top_p: 1.0,
+            seed: None,
+        };
+        let mut rng = XorShiftRng::new(42);
+        for _ in 0..100 {
+            let token = sample_token(&logits, &config, &mut rng);
+            assert!((token as usize) < 100, "Token out of range: {}", token);
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,4 +47,7 @@ pub enum InferenceError {
 
     #[error("Model error: {0}")]
     Model(String),
+
+    #[error("Generation error: {0}")]
+    Generation(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod engine;
 
 pub use error::InferenceError;
 pub use engine::EmbeddingEngine;
+pub use engine::GenerationEngine;
 pub use tokenizer::create_tokenizer_from_gguf;

--- a/src/model/cache.rs
+++ b/src/model/cache.rs
@@ -1,0 +1,340 @@
+// M6: KV cache for autoregressive generation.
+//
+// Stores cached K and V projections for each layer, enabling efficient
+// single-token decode steps without recomputing past K/V values.
+
+use crate::error::InferenceError;
+use super::config::ModelConfig;
+
+/// Per-layer KV cache for autoregressive generation.
+///
+/// Pre-allocates buffers for `max_seq_len` positions across all layers.
+/// During generation, new K/V values are appended after each forward step,
+/// and the full cached K/V is read for attention computation.
+pub struct KvCache {
+    /// Per-layer K cache: each Vec has capacity for max_seq_len * kv_dim.
+    k_cache: Vec<Vec<f32>>,
+    /// Per-layer V cache: each Vec has capacity for max_seq_len * kv_dim.
+    v_cache: Vec<Vec<f32>>,
+    /// Number of positions filled so far (same across all layers).
+    pos: usize,
+    /// Maximum sequence length this cache supports.
+    max_seq_len: usize,
+    /// KV dimension per position: num_kv_heads * head_dim.
+    kv_dim: usize,
+    /// Number of transformer layers.
+    num_layers: usize,
+}
+
+impl KvCache {
+    /// Create a new KV cache pre-allocated for the given model configuration.
+    pub fn new(config: &ModelConfig) -> Self {
+        let kv_dim = config.num_kv_heads * config.head_dim;
+        let num_layers = config.num_layers;
+        let max_seq_len = config.max_seq_len;
+        let capacity = max_seq_len * kv_dim;
+
+        let k_cache = (0..num_layers).map(|_| Vec::with_capacity(capacity)).collect();
+        let v_cache = (0..num_layers).map(|_| Vec::with_capacity(capacity)).collect();
+
+        Self {
+            k_cache,
+            v_cache,
+            pos: 0,
+            max_seq_len,
+            kv_dim,
+            num_layers,
+        }
+    }
+
+    /// Append new K/V values for a single layer.
+    ///
+    /// `k_new` and `v_new` should each contain `n_tokens * kv_dim` elements.
+    pub fn append(
+        &mut self,
+        layer: usize,
+        k_new: &[f32],
+        v_new: &[f32],
+        n_tokens: usize,
+    ) -> Result<(), InferenceError> {
+        if layer >= self.num_layers {
+            return Err(InferenceError::Generation(format!(
+                "KV cache layer index {} out of bounds (num_layers={})",
+                layer, self.num_layers
+            )));
+        }
+        let expected_len = n_tokens * self.kv_dim;
+        if k_new.len() != expected_len || v_new.len() != expected_len {
+            return Err(InferenceError::Generation(format!(
+                "KV cache append: expected {} elements ({}*{}), got k={} v={}",
+                expected_len, n_tokens, self.kv_dim, k_new.len(), v_new.len()
+            )));
+        }
+        if self.pos + n_tokens > self.max_seq_len {
+            return Err(InferenceError::Generation(format!(
+                "KV cache overflow: pos={} + n_tokens={} > max_seq_len={}",
+                self.pos, n_tokens, self.max_seq_len
+            )));
+        }
+        self.k_cache[layer].extend_from_slice(k_new);
+        self.v_cache[layer].extend_from_slice(v_new);
+        Ok(())
+    }
+
+    /// Read cached K values for a layer.
+    ///
+    /// The returned slice contains all appended K data for this layer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `layer >= num_layers`. Use `num_layers()` to check bounds.
+    pub fn get_k(&self, layer: usize) -> &[f32] {
+        &self.k_cache[layer]
+    }
+
+    /// Read cached V values for a layer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `layer >= num_layers`. Use `num_layers()` to check bounds.
+    pub fn get_v(&self, layer: usize) -> &[f32] {
+        &self.v_cache[layer]
+    }
+
+    /// Number of positions filled so far (before the current step's tokens).
+    pub fn len(&self) -> usize {
+        self.pos
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.pos == 0
+    }
+
+    /// Advance the position counter after all layers have processed a step.
+    pub fn advance(&mut self, n_tokens: usize) {
+        self.pos += n_tokens;
+    }
+
+    /// Reset the cache for a new sequence.
+    pub fn clear(&mut self) {
+        self.pos = 0;
+        for k in &mut self.k_cache {
+            k.clear();
+        }
+        for v in &mut self.v_cache {
+            v.clear();
+        }
+    }
+
+    /// The KV dimension (num_kv_heads * head_dim).
+    pub fn kv_dim(&self) -> usize {
+        self.kv_dim
+    }
+
+    /// The maximum sequence length.
+    pub fn max_seq_len(&self) -> usize {
+        self.max_seq_len
+    }
+
+    /// The number of layers.
+    pub fn num_layers(&self) -> usize {
+        self.num_layers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::config::*;
+
+    fn test_config(num_layers: usize) -> ModelConfig {
+        ModelConfig {
+            arch: ModelArch::Gemma3,
+            arch_name: "gemma3".to_string(),
+            hidden_size: 8,
+            num_layers,
+            num_heads: 2,
+            num_kv_heads: 2,
+            head_dim: 4,
+            ffn_hidden: 32,
+            vocab_size: 16,
+            max_seq_len: 64,
+            norm_type: NormType::RMSNorm,
+            norm_eps: 1e-6,
+            activation: Activation::SwiGLU,
+            position_type: PositionType::RoPE,
+            rope_freq_base: 10000.0,
+            rope_dim: 4,
+            causal: true,
+            attn_logit_softcap: 0.0,
+            attn_scale: None,
+            embedding_scale: 1.0,
+            pooling_type: PoolingType::None,
+            has_ffn_gate: true,
+            has_bias: false,
+            pre_norm: true,
+        }
+    }
+
+    #[test]
+    fn test_new_cache() {
+        let config = test_config(2);
+        let cache = KvCache::new(&config);
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+        assert_eq!(cache.kv_dim(), 8); // 2 heads * 4 dim
+        assert_eq!(cache.num_layers(), 2);
+        assert_eq!(cache.max_seq_len(), 64);
+    }
+
+    #[test]
+    fn test_append_and_get() {
+        let config = test_config(1);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim(); // 8
+
+        // Append 2 tokens for layer 0
+        let k = vec![1.0f32; 2 * kv_dim];
+        let v = vec![2.0f32; 2 * kv_dim];
+        cache.append(0, &k, &v, 2).unwrap();
+        cache.advance(2);
+
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.is_empty());
+        assert_eq!(cache.get_k(0).len(), 2 * kv_dim);
+        assert_eq!(cache.get_v(0).len(), 2 * kv_dim);
+        assert!(cache.get_k(0).iter().all(|&x| x == 1.0));
+        assert!(cache.get_v(0).iter().all(|&x| x == 2.0));
+    }
+
+    #[test]
+    fn test_append_sequential() {
+        let config = test_config(1);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        // First append: 1 token
+        let k1 = vec![1.0f32; kv_dim];
+        let v1 = vec![10.0f32; kv_dim];
+        cache.append(0, &k1, &v1, 1).unwrap();
+        cache.advance(1);
+        assert_eq!(cache.len(), 1);
+
+        // Second append: 1 token
+        let k2 = vec![2.0f32; kv_dim];
+        let v2 = vec![20.0f32; kv_dim];
+        cache.append(0, &k2, &v2, 1).unwrap();
+        cache.advance(1);
+        assert_eq!(cache.len(), 2);
+
+        // Verify combined cache
+        let k_all = cache.get_k(0);
+        assert_eq!(k_all.len(), 2 * kv_dim);
+        assert!(k_all[..kv_dim].iter().all(|&x| x == 1.0));
+        assert!(k_all[kv_dim..].iter().all(|&x| x == 2.0));
+    }
+
+    #[test]
+    fn test_clear() {
+        let config = test_config(1);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        cache.append(0, &vec![1.0; kv_dim], &vec![2.0; kv_dim], 1).unwrap();
+        cache.advance(1);
+        assert_eq!(cache.len(), 1);
+
+        cache.clear();
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+        assert_eq!(cache.get_k(0).len(), 0);
+        assert_eq!(cache.get_v(0).len(), 0);
+    }
+
+    #[test]
+    fn test_multi_layer() {
+        let config = test_config(3);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        // Append to each layer with different values
+        for layer in 0..3 {
+            let k = vec![(layer + 1) as f32; kv_dim];
+            let v = vec![(layer + 10) as f32; kv_dim];
+            cache.append(layer, &k, &v, 1).unwrap();
+        }
+        cache.advance(1);
+
+        // Verify each layer has its own data
+        assert!(cache.get_k(0).iter().all(|&x| x == 1.0));
+        assert!(cache.get_k(1).iter().all(|&x| x == 2.0));
+        assert!(cache.get_k(2).iter().all(|&x| x == 3.0));
+        assert!(cache.get_v(0).iter().all(|&x| x == 10.0));
+        assert!(cache.get_v(1).iter().all(|&x| x == 11.0));
+        assert!(cache.get_v(2).iter().all(|&x| x == 12.0));
+    }
+
+    #[test]
+    fn test_overflow_returns_error() {
+        let mut config = test_config(1);
+        config.max_seq_len = 2;
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        // Fill to capacity
+        cache.append(0, &vec![1.0; 2 * kv_dim], &vec![2.0; 2 * kv_dim], 2).unwrap();
+        cache.advance(2);
+
+        // This should fail
+        let result = cache.append(0, &vec![3.0; kv_dim], &vec![4.0; kv_dim], 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wrong_size_returns_error() {
+        let config = test_config(1);
+        let mut cache = KvCache::new(&config);
+
+        // Wrong number of elements
+        let result = cache.append(0, &[1.0, 2.0], &[3.0, 4.0], 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_layer_out_of_bounds_returns_error() {
+        let config = test_config(2);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        // Layer index 2 is out of bounds for 2-layer cache (valid: 0, 1)
+        let result = cache.append(2, &vec![1.0; kv_dim], &vec![2.0; kv_dim], 1);
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("out of bounds"), "Error: {}", err_msg);
+    }
+
+    #[test]
+    fn test_clear_then_reuse() {
+        let config = test_config(1);
+        let mut cache = KvCache::new(&config);
+        let kv_dim = cache.kv_dim();
+
+        // Fill with some data
+        cache.append(0, &vec![1.0; 2 * kv_dim], &vec![2.0; 2 * kv_dim], 2).unwrap();
+        cache.advance(2);
+        assert_eq!(cache.len(), 2);
+
+        // Clear
+        cache.clear();
+        assert_eq!(cache.len(), 0);
+
+        // Reuse — should work and contain only the new data
+        cache.append(0, &vec![3.0; kv_dim], &vec![4.0; kv_dim], 1).unwrap();
+        cache.advance(1);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get_k(0).len(), kv_dim);
+        assert!(cache.get_k(0).iter().all(|&x| x == 3.0));
+        assert!(cache.get_v(0).iter().all(|&x| x == 4.0));
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,8 @@
 pub mod config;
 pub mod weights;
 pub mod layer;
+pub mod cache;
 
 pub use config::{ModelConfig, ModelArch, NormType, Activation, PositionType, PoolingType};
 pub use weights::{ModelWeights, LayerWeights};
+pub use cache::KvCache;

--- a/src/model/weights.rs
+++ b/src/model/weights.rs
@@ -67,6 +67,10 @@ pub struct ModelWeights {
     /// Final output normalization weight: [hidden_size]
     pub output_norm_w: DeviceTensor,
     pub output_norm_b: Option<DeviceTensor>,
+
+    /// Output projection (lm_head): [vocab_size, hidden_size]
+    /// When None, generation falls back to tied embeddings (token_embedding).
+    pub output_projection: Option<DeviceTensor>,
 }
 
 // ---------------------------------------------------------------------------
@@ -403,8 +407,12 @@ impl ModelWeights {
             None
         };
 
+        // -- Output projection (lm_head) --
+        let output_projection = load_tensor_optional(gguf, "output.weight", backend)?;
+
         info!(
             num_layers = layers.len(),
+            has_output_projection = output_projection.is_some(),
             "Model weights loaded successfully"
         );
 
@@ -416,6 +424,7 @@ impl ModelWeights {
             layers,
             output_norm_w,
             output_norm_b,
+            output_projection,
         })
     }
 }


### PR DESCRIPTION
## Summary

- **KV cache** (`src/model/cache.rs`): Per-layer K/V storage with append/get/clear, overflow protection, and layer bounds validation
- **Cached attention** (`src/model/layer.rs`): `multi_head_attention_cached()` with RoPE position offset, GQA expansion, causal masking during prefill, and `model_forward_step()` as the cached variant of `model_forward()`
- **Sampling** (`src/engine/sampler.rs`): Greedy (argmax), temperature scaling, top-k, top-p (nucleus) filtering with zero-dependency XorShift64 RNG
- **GenerationEngine** (`src/engine/generate.rs`): `from_gguf()` loading with causal model validation, `generate(prompt) → String`, `generate_stream(prompt, callback)`, tied embeddings fallback when `output.weight` is absent
- **Supporting changes**: `Generation(String)` error variant, `output_projection` field in `ModelWeights`, module wiring in `mod.rs`/`lib.rs`

## Key design decisions

- **Cache stores raw `Vec<f32>` per layer** — avoids `DeviceTensor` overhead for the cache hot path; K/V are appended as flat slices and read back for attention
- **Causal mask only during prefill** (`n_new > 1`) — single-token decode naturally attends to all cached positions, no masking needed
- **Causal validation at both `from_gguf()` and `generate()` call sites** — prevents misuse via test constructors
- **No `rand` crate** — XorShift64 keeps the zero-C-dependency principle; deterministic with seed

## Stats

- 10 files changed (3 new, 7 modified), ~2,000 LOC added
- 506 tests passing, 0 warnings, 8 ignored (integration tests requiring real GGUF files)

## Test plan

- [x] KV cache: new/append/get/clear/multi-layer/overflow/bounds/clear-then-reuse (9 tests)
- [x] Cached forward: output shape, single-token decode, cached-vs-uncached match, multi-layer, GQA (5 tests)
- [x] Sampling: argmax, greedy, temperature, top-k, top-p, combined, RNG range, determinism (14 tests)
- [x] GenerationEngine: greedy deterministic, max_tokens, EOS stop, stream callback, non-causal rejection, empty prompt, context overflow, explicit stop tokens, max_tokens=0, generate/stream consistency (12 tests)
- [ ] Integration tests with real GGUF model (remain `#[ignore]` until test artifact available)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)