### PR TITLE
Fix BPE tokenizer for GPT-2 byte-level encoding

### DIFF
--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -178,7 +178,7 @@ pub fn create_tokenizer_from_gguf(
             .map(|v| v.into_iter().map(|s| s.to_string()).collect())
             .unwrap_or_default();
 
-        let add_bos = gguf.get_bool("tokenizer.ggml.add_bos_token").unwrap_or(true);
+        let add_bos = gguf.get_bool("tokenizer.ggml.add_bos_token").unwrap_or(false);
         let add_eos = gguf.get_bool("tokenizer.ggml.add_eos_token").unwrap_or(false);
 
         Ok(Box::new(BpeTokenizer::new(


### PR DESCRIPTION
## Summary

- **Add GPT-2 byte-level encoding** — implements the 256-entry `BYTE_TO_UNICODE` / `UNICODE_TO_BYTE` lookup tables matching llama.cpp's `unicode_byte_to_utf8_map()`, and byte-encodes pre-tokenized pieces before BPE merging
- **Fix byte fallback and decode paths** — GPT-2 uses byte-table tokens (e.g. `Ġ` for space) instead of `<0xNN>` format; decode now reverses the byte mapping correctly for each mode
- **Fix `add_bos` default** — changed from `true` to `false` so GPT-2 models (which don't set `tokenizer.ggml.add_bos_token`) no longer get a spurious BOS token prepended

Closes #45

## Test plan

- [x] All 537 existing unit tests pass (`cargo test`)
- [x] 12 new unit tests for byte encoding tables, GPT-2 encode/decode roundtrip, and byte fallback
- [x] **100/100 PASS** on stress test against llama.cpp with `gpt2-Q8_0.gguf` (100 sentences covering ASCII, Unicode, contractions, code, punctuation, whitespace edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)