### PR TITLE
Add regex-BPE pre-tokenizer for LLaMA 3, DeepSeek, Qwen, Command-R

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +160,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -448,6 +474,7 @@ name = "strata-inference"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fancy-regex",
  "half",
  "memmap2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tracing = "0.1"
 half = { version = "2", features = ["std"] }
 memmap2 = "0.9"
 unicode-normalization = "0.1"
+fancy-regex = "0.14"
 
 # CLI-only dependencies (behind "cli" feature)
 clap = { version = "4", features = ["derive"], optional = true }

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -192,6 +192,10 @@ pub fn create_tokenizer_from_gguf(
             .get_bool("tokenizer.ggml.add_space_prefix")
             .unwrap_or(true);
 
+        // Read the pre-tokenizer type (determines regex pattern for rank-based BPE).
+        // SentencePiece models typically don't have this key.
+        let pre_type = gguf.get_str("tokenizer.ggml.pre");
+
         Ok(Box::new(BpeTokenizer::new(
             tokens,
             scores,
@@ -203,6 +207,7 @@ pub fn create_tokenizer_from_gguf(
             add_bos,
             add_eos,
             add_space_prefix,
+            pre_type,
         )))
     }
 }


### PR DESCRIPTION
## Summary
- Add `fancy-regex`-based pre-tokenization using `tokenizer.ggml.pre` from GGUF metadata to select the correct regex pattern per model family (LLaMA 3, DeepSeek, Qwen 2, Command-R, GPT-2)
- Extend special token partitioning to include CONTROL tokens (type=3) alongside USER_DEFINED (type=4), matching llama.cpp's `cache_special_tokens` behavior
- Add NFC normalization for the SentencePiece encode path

## Test plan
- [x] 553 unit tests pass (537 existing + 16 new)
- [x] Gemma 3 stress test: 102/102 PASS
- [x] TinyLlama stress test: 102/102 PASS
- [x] GPT-2 vocab stress test: 102/102 PASS
- [x] LLaMA-BPE vocab stress test: 102/102 PASS (exercises the new regex path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)