### PR TITLE
Add GemmaEmbedding architecture and fix BERT output_norm

### DIFF
--- a/src/engine/embed.rs
+++ b/src/engine/embed.rs
@@ -358,6 +358,10 @@ mod tests {
             ffn_gate: Some(zero_weight(ffn, h)),
             ffn_up_bias: None,
             ffn_down_bias: None,
+            attn_q_norm_w: None,
+            attn_k_norm_w: None,
+            attn_post_norm_w: None,
+            ffn_post_norm_w: None,
         };
 
         ModelWeights {
@@ -366,7 +370,7 @@ mod tests {
             embedding_norm_w: None,
             embedding_norm_b: None,
             layers: vec![layer],
-            output_norm_w: ones_weight(h),
+            output_norm_w: Some(ones_weight(h)),
             output_norm_b: None,
             output_projection: None,
         }

--- a/src/engine/generate.rs
+++ b/src/engine/generate.rs
@@ -601,6 +601,10 @@ mod tests {
             ffn_gate: Some(zero_weight(ffn, h)),
             ffn_up_bias: None,
             ffn_down_bias: None,
+            attn_q_norm_w: None,
+            attn_k_norm_w: None,
+            attn_post_norm_w: None,
+            ffn_post_norm_w: None,
         };
 
         ModelWeights {
@@ -609,7 +613,7 @@ mod tests {
             embedding_norm_w: None,
             embedding_norm_b: None,
             layers: vec![layer],
-            output_norm_w: ones_weight(h),
+            output_norm_w: Some(ones_weight(h)),
             output_norm_b: None,
             output_projection: None, // tied embeddings
         }


### PR DESCRIPTION
## Summary

- **GemmaEmbedding support**: Full `gemma-embedding` architecture with per-head Q/K RMSNorm, post-attention/FFN norms, GeGLU activation, bidirectional attention, and GQA dispatch in `transformer_layer_forward`
- **BERT fix**: Make `output_norm_w` optional (`Option<DeviceTensor>`) so BERT models (MiniLM, etc.) no longer fail with "Tensor not found: output_norm.weight"
- **4 new `LayerWeights` fields**: `attn_q_norm_w`, `attn_k_norm_w`, `attn_post_norm_w`, `ffn_post_norm_w` — loaded from GGUF for GemmaEmbedding, `None` for all other architectures
- **12 new tests**: per-head norm correctness, GQA shape handling, post-norm effects, bidirectional attention verification, BERT without output norm, end-to-end model_forward

## Test plan

- [x] `cargo test --lib` — 615 passed, 0 failed, 8 ignored
- [x] `strata-embed -m all-MiniLM-L6-v2.Q8_0.gguf` produces 384-dim embeddings (BERT)
- [x] `strata-embed -m embeddinggemma-300M-Q8_0.gguf` produces 768-dim embeddings (GemmaEmbedding)
- [ ] Benchmark cosine similarity > 0.99 vs llama-embedding for both models

🤖 Generated with [Claude Code](https://claude.com/claude-code)