### PR TITLE
Fix three embedding correctness issues vs llama.cpp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,7 @@ dependencies = [
  "clap",
  "fancy-regex",
  "half",
+ "libm",
  "memmap2",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 thiserror = "2"
 tracing = "0.1"
 half = { version = "2", features = ["std"] }
+libm = "0.2"
 memmap2 = "0.9"
 unicode-normalization = "0.1"
 fancy-regex = "0.14"

--- a/src/backend/metal/mod.rs
+++ b/src/backend/metal/mod.rs
@@ -676,7 +676,9 @@ impl ComputeBackend for MetalBackend {
                 trace!(shape = ?shape, "Metal download F16");
                 Tensor::from_f16(shape, data)
             }
-            TensorDtype::Q8_0 | TensorDtype::Q4_0 => {
+            TensorDtype::Q8_0 | TensorDtype::Q4_0
+            | TensorDtype::Q4_1 | TensorDtype::Q5_0 | TensorDtype::Q5_1
+            | TensorDtype::Q4_K | TensorDtype::Q5_K | TensorDtype::Q6_K => {
                 let n_elements: usize = shape.iter().product();
                 let block_size = dtype.block_size();
                 let block_byte_size = dtype.block_byte_size();

--- a/src/engine/embed.rs
+++ b/src/engine/embed.rs
@@ -311,6 +311,7 @@ mod tests {
             position_type: PositionType::RoPE,
             rope_freq_base: 10000.0,
             rope_dim: hidden_size,
+            rope_neox: false,
             causal: false, // bidirectional for embedding
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -367,6 +368,7 @@ mod tests {
         ModelWeights {
             token_embedding: dt(Tensor::new(vec![v, h], emb_data)),
             position_embedding: None,
+            token_type_embedding: None,
             embedding_norm_w: None,
             embedding_norm_b: None,
             layers: vec![layer],

--- a/src/engine/generate.rs
+++ b/src/engine/generate.rs
@@ -555,6 +555,7 @@ mod tests {
             position_type: PositionType::RoPE,
             rope_freq_base: 10000.0,
             rope_dim: hidden_size,
+            rope_neox: false,
             causal: true,
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -610,6 +611,7 @@ mod tests {
         ModelWeights {
             token_embedding: dt(Tensor::new(vec![v, h], emb_data)),
             position_embedding: None,
+            token_type_embedding: None,
             embedding_norm_w: None,
             embedding_norm_b: None,
             layers: vec![layer],

--- a/src/model/cache.rs
+++ b/src/model/cache.rs
@@ -166,6 +166,7 @@ mod tests {
             position_type: PositionType::RoPE,
             rope_freq_base: 10000.0,
             rope_dim: 4,
+            rope_neox: false,
             causal: true,
             attn_logit_softcap: 0.0,
             attn_scale: None,


### PR DESCRIPTION
## Summary

- **BERT token type embeddings**: Load `token_types.weight` from GGUF and add row 0 to all token embeddings. Fixes MiniLM cosine 0.50-0.95 → 0.999999
- **Exact GELU**: Replace tanh approximation with `erf`-based exact GELU (`libm` dep) to match llama.cpp's BERT path
- **NeoX-style RoPE for Gemma**: Add `rope_neox` config flag — Gemma3, Gemma2, and GemmaEmbedding all use pairs offset by n_rot/2. Fixes EmbedGemma cosine 0.96-0.98 → 0.995-0.999

## Test plan

- [x] `cargo test --lib` — 615 passed, 0 failed
- [x] Benchmark vs llama-embedding: MiniLM cosine=0.999999, EmbedGemma cosine=0.996-0.999 (10/10 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)