### PR TITLE
Optimize Metal decode: fix rms_norm_per_head bottleneck (+30% tok/s)

### DIFF
--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -1582,6 +1582,30 @@ impl ComputeBackend for CudaBackend {
 
         (q_out, k_out)
     }
+
+    fn copy_rows_into(
+        &self,
+        _dest: &DeviceTensor,
+        _src: &DeviceTensor,
+        _dest_row_offset: usize,
+    ) {
+        todo!("CUDA copy_rows_into not yet implemented");
+    }
+
+    fn grouped_attention_decode(
+        &self,
+        _q: &DeviceTensor,
+        _k: &DeviceTensor,
+        _v: &DeviceTensor,
+        _total_len: usize,
+        _num_heads: usize,
+        _num_kv_heads: usize,
+        _head_dim: usize,
+        _attn_scale: f32,
+        _softcap: f32,
+    ) -> DeviceTensor {
+        todo!("CUDA grouped_attention_decode not yet implemented");
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix `rms_norm_per_head` bottleneck**: Reshape `[seq_len, num_heads * head_dim]` → `[seq_len * num_heads, head_dim]` and call `rms_norm` once, eliminating N GPU-CPU roundtrips per layer (38ms → 6μs per call). This was the dominant source of decode latency.
- **Skip `project_to_logits` roundtrip during decode**: When hidden is already `[1, hidden_size]` on the device, avoid unnecessary download → slice → upload.
- **Fast path for `quantized_matmul` with M=1 GPU inputs**: Bind the GPU buffer directly instead of flushing and copying per-row.
- **Add GPU KV cache + grouped attention decode kernel infrastructure**: New `copy_rows_into`, `grouped_attention_decode` backend ops with Metal MSL kernel and CPU reference. Currently disabled (`is_gpu()` returns false) because `copy_rows_into` flush stalls make the GPU path slower — re-enable after implementing async GPU buffer copies.

**Benchmark (Qwen3-1.7B Q8_0, Metal):**
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Decode | 1.64 tok/s | 2.13 tok/s | **+30%** |
| Prefill | 3.52 tok/s | 3.92 tok/s | **+11%** |

Output is bit-identical to baseline.

## Test plan

- [x] `cargo test --lib` — 656 CPU tests pass
- [x] `cargo test --lib --features metal` — 674 Metal tests pass (2 pre-existing rope failures)
- [x] 4 new `grouped_attention_decode` tests (basic, GQA, softcap, single-token)
- [x] End-to-end generation with Qwen3-1.7B Q8_0 on Metal — output matches CPU baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)