### PR TITLE
Add batched quantized GEMM kernels for Metal prefill

### DIFF
--- a/src/metal_gen/exec.rs
+++ b/src/metal_gen/exec.rs
@@ -98,6 +98,17 @@ impl MetalResources {
             "gemm_transpose_bias",           // MatmulTransposeBias = 27
             "batched_causal_attention",      // BatchedCausalAttention = 28
             "batched_causal_attention_f16",  // BatchedCausalAttentionF16 = 29
+            // Phase 4: Batched quantized matmul for prefill
+            "batched_matmul_q8_0",           // BatchedMatmulQ8_0 = 30
+            "batched_matmul_bias_q8_0",      // BatchedMatmulBiasQ8_0 = 31
+            "batched_matmul_q4_0",           // BatchedMatmulQ4_0 = 32
+            "batched_matmul_bias_q4_0",      // BatchedMatmulBiasQ4_0 = 33
+            "batched_matmul_q4_k",           // BatchedMatmulQ4K = 34
+            "batched_matmul_bias_q4_k",      // BatchedMatmulBiasQ4K = 35
+            "batched_matmul_q5_k",           // BatchedMatmulQ5K = 36
+            "batched_matmul_bias_q5_k",      // BatchedMatmulBiasQ5K = 37
+            "batched_matmul_q6_k",           // BatchedMatmulQ6K = 38
+            "batched_matmul_bias_q6_k",      // BatchedMatmulBiasQ6K = 39
         ];
 
         let mut psos = Vec::with_capacity(kernel_names.len());


### PR DESCRIPTION
## Summary

- Add 10 batched GEMM Metal kernels (Q8_0, Q4_0, Q4_K, Q5_K, Q6_K × bias/no-bias) with simdgroup_matrix tiling and fused dequantization
- Replace per-row M=1 dispatch loop in `emit_linear_multi` with single-dispatch batched GEMM, reducing quantized matmul dispatches by 97% (2,088 → 72 for GPT-2 Q8_0 M=29)
- Total prefill ops drop from ~2,262 to ~174; prefill scales from ~810 tok/s (M=29) to ~2,000 tok/s (M=233)

## Performance (GPT-2 Q8_0, Apple M1 Pro)

| Prompt tokens | Prefill (tok/s) | vs Phase 3 baseline |
|---|---|---|
| 29 | 810 | 1.10x |
| 136 | 1,744 | 2.36x |
| 233 | 2,035 | 2.75x |

Decode unchanged (~182 tok/s) since M=1 decode still uses optimized mat-vec kernels.

## Correctness

Greedy decoding output matches llama.cpp exactly across all tested prompts. 738 unit tests pass (22 prefill-specific).

## Test plan

- [x] `cargo test --lib --features metal` — 738 passed, 0 failed
- [x] Correctness: greedy output matches llama.cpp on 4 prompts (short/medium/long)
- [x] Prefill benchmark at M=29, 136, 233
- [x] TinyLlama Q4_K model runs correctly with K-quant batched kernels

🤖 Generated with [Claude Code](https://claude.com/claude-code)