### PR TITLE
Fix Phi-3/3.5 implementation gaps

### DIFF
--- a/src/bin/metal_generate.rs
+++ b/src/bin/metal_generate.rs
@@ -40,6 +40,10 @@ struct Args {
     /// Debug: dump first N logits from graph decode
     #[arg(long, default_value = "0")]
     debug_logits: usize,
+
+    /// Context size (KV cache length). Defaults to min(model context_length, 4096).
+    #[arg(long)]
+    ctx: Option<usize>,
 }
 
 fn main() {
@@ -60,7 +64,7 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load model via unified GenerationEngine with Metal backend
     let load_start = Instant::now();
-    let mut engine = GenerationEngine::from_gguf_with_backend(&args.model, "metal")?;
+    let mut engine = GenerationEngine::from_gguf_with_options(&args.model, "metal", args.ctx)?;
     let load_ms = load_start.elapsed().as_secs_f64() * 1000.0;
     eprintln!("[timing] model load: {:.1}ms", load_ms);
 

--- a/src/engine/embed.rs
+++ b/src/engine/embed.rs
@@ -312,6 +312,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: hidden_size,
             rope_neox: false,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: false, // bidirectional for embedding
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -375,6 +377,8 @@ mod tests {
             output_norm_w: Some(ones_weight(h)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         }
     }
 

--- a/src/engine/exec_metal.rs
+++ b/src/engine/exec_metal.rs
@@ -177,6 +177,8 @@ impl MetalResources {
             "batched_matmul_bias_q5_k",      // BatchedMatmulBiasQ5K = 37
             "batched_matmul_q6_k",           // BatchedMatmulQ6K = 38
             "batched_matmul_bias_q6_k",      // BatchedMatmulBiasQ6K = 39
+            // Phase 5: RoPE with per-dimension frequency factors (LongRoPE)
+            "rope_neox_factors",             // RopeNeoxFactors = 40
         ];
 
         let mut psos = Vec::with_capacity(kernel_names.len());

--- a/src/model/cache.rs
+++ b/src/model/cache.rs
@@ -322,6 +322,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: 4,
             rope_neox: false,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: true,
             attn_logit_softcap: 0.0,
             attn_scale: None,

--- a/src/model/layer.rs
+++ b/src/model/layer.rs
@@ -1041,6 +1041,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: head_dim,
             rope_neox: false,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: true,
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -1072,6 +1074,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: head_dim,
             rope_neox: false,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: false,
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -1606,6 +1610,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[1u32, 3, 5];
@@ -1642,6 +1648,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: Some(zeros_bias(hidden_size)),
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[0u32, 2, 4, 6];
@@ -1683,6 +1691,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[0u32];
@@ -1724,6 +1734,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[1u32, 5];
@@ -1757,6 +1769,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[3u32];
@@ -1936,6 +1950,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         // Token ID 100 exceeds vocab_size=8 (note: config has vocab_size=16, override)
@@ -1977,6 +1993,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mut cache = KvCache::new(&config);
@@ -2011,6 +2029,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mut cache = KvCache::new(&config);
@@ -2052,6 +2072,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[1u32, 3, 5];
@@ -2102,6 +2124,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mut cache = KvCache::new(&config);
@@ -2175,6 +2199,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mut cache = KvCache::new(&config);
@@ -2310,6 +2336,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: head_dim,
             rope_neox: false,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: false,
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -2537,6 +2565,8 @@ mod tests {
             output_norm_w: None,
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[0u32, 2, 4, 6];
@@ -2576,6 +2606,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[1u32, 3, 5];
@@ -2602,6 +2634,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
         let output_no_scale = model_forward(input_ids, attention_mask, &weights2, &config_no_scale, &b, 0).unwrap();
         let d1 = output.as_tensor().as_f32();
@@ -2653,6 +2687,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mask = &[1.0f32, 1.0, 1.0];
@@ -2695,6 +2731,8 @@ mod tests {
             rope_freq_base: 10000.0,
             rope_dim: head_dim,
             rope_neox: true,
+            rope_scaling_original_ctx: 0,
+            rope_scaling_attn_factor: 1.0,
             causal: true,
             attn_logit_softcap: 0.0,
             attn_scale: None,
@@ -2864,6 +2902,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let mut cache = KvCache::new(&config);
@@ -2909,6 +2949,8 @@ mod tests {
             output_norm_w: Some(ones_weight(hidden_size)),
             output_norm_b: None,
             output_projection: None,
+            rope_factors_short: None,
+            rope_factors_long: None,
         };
 
         let input_ids = &[1u32, 3, 5];

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -227,6 +227,17 @@ impl Tensor {
         }
     }
 
+    /// Returns a reference to the underlying raw quantized bytes.
+    ///
+    /// # Panics
+    /// Panics if the tensor is not a quantized dtype.
+    pub fn quantized_data(&self) -> &[u8] {
+        match &self.storage {
+            TensorStorage::Quantized(data) => data,
+            _ => panic!("Tensor is {:?}, not quantized", self.dtype),
+        }
+    }
+
     /// Returns a mutable reference to the underlying F32 data.
     ///
     /// # Panics


### PR DESCRIPTION
## Summary

- **Fix `has_bias` for Phi-3**: Changed from `true` to `false` — real Phi-3.5-mini-instruct has zero bias tensors (uses RMSNorm, not LayerNorm)
- **Add YaRN `attn_factor` / mscale support**: Load `rope.scaling.attn_factor` from GGUF, compute YaRN mscale, apply mscale² to attention scale, and add mscale parameter to `rope_neox_factors` Metal kernel
- **Implement LongRoPE runtime factor selection**: At decode time, swap the rope factors Metal buffer from short→long when sequence length exceeds `rope_scaling_original_ctx`
- **Add rope_factors shape validation**: Verify loaded factors have exactly `rope_dim/2` elements
- **Fix Phi-3 test configs**: Update test to use MHA (32 KV heads, not 8) matching the real model
- **Add Phi-3 graph tests**: 6 new tests verifying op count, op sequence, RoPE style, no-bias ops, LongRoPE factors, and weight walk order
- **Add quantized split test**: `test_fused_gate_up_q8_0_split` verifies byte-level splitting preserves Q8_0 format

## Test plan

- [x] `cargo test --lib` — 705 passed, 0 failed, 8 ignored
- [x] All 7 new Phi-3 graph tests pass
- [x] Q8_0 fused gate+up split test passes
- [x] Existing tests unaffected (only additive field `rope_scaling_attn_factor: 1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)