### PR TITLE
Add model registry with CLI support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -66,6 +72,12 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -87,6 +99,22 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -141,6 +169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -180,10 +217,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -229,6 +293,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "id-arena"
@@ -321,12 +401,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -340,6 +430,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -399,6 +495,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +518,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -470,6 +615,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +648,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
+ "ureq",
 ]
 
 [[package]]
@@ -498,6 +656,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -517,10 +681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -650,6 +814,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +865,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -714,10 +925,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -727,6 +956,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -835,6 +1128,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
+# Registry dependencies (behind "registry" feature)
+ureq = { version = "3", optional = true }
+
 [dev-dependencies]
 tempfile = "3"
 
@@ -28,6 +31,7 @@ default = []
 cli = ["dep:clap", "dep:serde", "dep:serde_json", "dep:tracing-subscriber"]
 metal = []
 cuda = []
+registry = ["dep:ureq"]
 
 [[bin]]
 name = "strata-tokenize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,11 @@ path = "src/bin/generate.rs"
 required-features = ["cli"]
 
 [[bin]]
+name = "strata-models"
+path = "src/bin/models.rs"
+required-features = ["cli"]
+
+[[bin]]
 name = "strata-metal-generate"
 path = "src/bin/metal_generate.rs"
 required-features = ["cli", "metal"]

--- a/src/bin/models.rs
+++ b/src/bin/models.rs
@@ -1,0 +1,130 @@
+//! strata-models: Manage the strata model registry.
+
+use std::process;
+
+use clap::{Parser, Subcommand};
+
+use strata_inference::registry::{format_size, ModelRegistry, ModelTask};
+
+#[derive(Parser)]
+#[command(name = "strata-models", about = "Manage strata model registry")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// List available models
+    List {
+        /// Only show locally available models
+        #[arg(long)]
+        local: bool,
+    },
+    /// Download a model from HuggingFace
+    Pull {
+        /// Model name (e.g., "qwen3:8b", "miniLM")
+        name: String,
+    },
+    /// Print the local path for a model
+    Path {
+        /// Model name
+        name: String,
+    },
+}
+
+fn main() {
+    let args = Args::parse();
+
+    if let Err(e) = run(args) {
+        eprintln!("Error: {}", e);
+        process::exit(1);
+    }
+}
+
+fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let registry = ModelRegistry::new();
+
+    match args.command {
+        Command::List { local } => cmd_list(&registry, local),
+        Command::Pull { name } => cmd_pull(&registry, &name),
+        Command::Path { name } => cmd_path(&registry, &name),
+    }
+}
+
+fn cmd_list(registry: &ModelRegistry, local_only: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let models = if local_only {
+        registry.list_local()
+    } else {
+        registry.list_available()
+    };
+
+    if models.is_empty() {
+        if local_only {
+            eprintln!("No models downloaded yet.");
+            eprintln!("Run `strata-models list` to see available models.");
+            eprintln!("Run `strata-models pull <name>` to download one.");
+        } else {
+            eprintln!("No models in catalog.");
+        }
+        return Ok(());
+    }
+
+    // Print header
+    println!(
+        "{:<16} {:<10} {:<10} {}",
+        "NAME", "TASK", "SIZE", "STATUS"
+    );
+
+    for m in &models {
+        let task = match m.task {
+            ModelTask::Embed => "embed",
+            ModelTask::Generate => "generate",
+        };
+        let size = format_size(m.size_bytes);
+        let status = if m.is_local { "downloaded" } else { "-" };
+
+        println!("{:<16} {:<10} {:<10} {}", m.name, task, size, status);
+    }
+
+    Ok(())
+}
+
+fn cmd_pull(registry: &ModelRegistry, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "registry")]
+    {
+        use std::io::Write;
+
+        eprintln!("Resolving '{}'...", name);
+
+        let path = registry.pull_with_progress(name, |downloaded, total| {
+            if total > 0 {
+                let pct = (downloaded as f64 / total as f64 * 100.0) as u64;
+                let dl = format_size(downloaded);
+                let tot = format_size(total);
+                eprint!("\r  {} / {} ({}%)", dl, tot, pct);
+                let _ = std::io::stderr().flush();
+            }
+        })?;
+
+        eprintln!();
+        println!("{}", path.display());
+        Ok(())
+    }
+
+    #[cfg(not(feature = "registry"))]
+    {
+        let _ = (registry, name);
+        Err(
+            "Model downloading requires the 'registry' feature. Build with:\n  \
+             cargo build --features cli,registry --bin strata-models"
+                .into(),
+        )
+    }
+}
+
+fn cmd_path(registry: &ModelRegistry, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let path = registry.resolve(name)?;
+    println!("{}", path.display());
+    Ok(())
+}

--- a/src/bin/tokenize.rs
+++ b/src/bin/tokenize.rs
@@ -13,9 +13,9 @@ use strata_inference::tokenizer::create_tokenizer_from_gguf;
 #[derive(Parser)]
 #[command(name = "strata-tokenize", about = "Tokenize text using a GGUF model")]
 struct Args {
-    /// Path to GGUF model file
+    /// Model name or path to GGUF file (e.g., "tinyllama" or "./model.gguf")
     #[arg(short = 'm', long)]
-    model: PathBuf,
+    model: String,
 
     /// Text to tokenize
     #[arg(short = 'p', long, conflicts_with_all = ["file", "stdin"])]
@@ -80,13 +80,14 @@ fn main() {
 }
 
 fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let model_path = cli::model::resolve_model(&args.model)?;
     let input = cli::read_input(
         args.prompt.as_deref(),
         args.file.as_deref(),
         args.stdin,
     )?;
 
-    let gguf = GgufFile::open(&args.model)?;
+    let gguf = GgufFile::open(&model_path)?;
     let tokenizer = create_tokenizer_from_gguf(&gguf)?;
 
     let add_special_tokens = !args.no_bos;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! Shared CLI utilities for strata-inference binary tools.
 
 pub mod backend;
+pub mod model;
 
 use std::io::Read;
 use std::path::Path;

--- a/src/cli/model.rs
+++ b/src/cli/model.rs
@@ -1,0 +1,255 @@
+//! Model resolution from CLI `--model` argument.
+//!
+//! Detects whether the argument is a file path or a registry name,
+//! and returns a validated `PathBuf` to a local GGUF file.
+
+use std::path::PathBuf;
+
+use crate::error::InferenceError;
+
+/// Resolve a `--model` argument to a local GGUF file path.
+///
+/// Detection heuristic:
+/// - Contains `/` or `\` → treat as file path
+/// - Ends with `.gguf` (case-insensitive) → treat as file path
+/// - Otherwise → treat as registry name
+pub fn resolve_model(input: &str) -> Result<PathBuf, InferenceError> {
+    let path = PathBuf::from(input);
+
+    // Looks like a file path
+    let lower = input.to_ascii_lowercase();
+    if input.contains('/') || input.contains('\\') || lower.ends_with(".gguf") {
+        if !path.exists() {
+            return Err(InferenceError::Model(format!(
+                "Model file not found: {}",
+                path.display()
+            )));
+        }
+        return Ok(path);
+    }
+
+    // Try registry
+    let registry = crate::registry::ModelRegistry::new();
+    registry.resolve(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    // ===== File-path detection branch =====
+
+    #[test]
+    fn test_path_with_slash_returns_model_error() {
+        let err = resolve_model("/nonexistent/model.gguf").unwrap_err();
+        assert!(
+            matches!(err, InferenceError::Model(_)),
+            "Expected InferenceError::Model, got: {:?}",
+            err
+        );
+        let msg = format!("{}", err);
+        assert!(msg.contains("Model file not found"), "Error: {}", msg);
+        assert!(msg.contains("/nonexistent/model.gguf"), "Error: {}", msg);
+    }
+
+    #[test]
+    fn test_path_with_backslash_returns_model_error() {
+        let err = resolve_model("C:\\models\\model.gguf").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+
+    #[test]
+    fn test_gguf_extension_lowercase_returns_model_error() {
+        let err = resolve_model("model.gguf").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+
+    #[test]
+    fn test_gguf_extension_uppercase_returns_model_error() {
+        // Users on case-insensitive filesystems might type .GGUF
+        let err = resolve_model("model.GGUF").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+
+    #[test]
+    fn test_gguf_extension_mixed_case_returns_model_error() {
+        let err = resolve_model("model.Gguf").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+
+    #[test]
+    fn test_relative_path_with_slash_returns_model_error() {
+        // "./model.gguf" contains '/' → file-path branch
+        let err = resolve_model("./model.gguf").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+
+    #[test]
+    fn test_existing_file_path_resolves_successfully() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test-model.gguf");
+        std::fs::write(&file_path, b"fake gguf").unwrap();
+
+        let result = resolve_model(file_path.to_str().unwrap()).unwrap();
+        assert_eq!(result, file_path);
+    }
+
+    #[test]
+    fn test_existing_file_without_gguf_extension_resolves_via_slash() {
+        // A path like "/tmp/xxx/mymodel" has a '/' so takes the file-path branch
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("mymodel");
+        std::fs::write(&file_path, b"fake").unwrap();
+
+        let result = resolve_model(file_path.to_str().unwrap()).unwrap();
+        assert_eq!(result, file_path);
+    }
+
+    // ===== Registry branch =====
+
+    #[test]
+    fn test_unknown_name_returns_registry_error() {
+        // A bare name without / or .gguf goes through the registry
+        let err = resolve_model("nonexistent-model-xyz").unwrap_err();
+        assert!(
+            matches!(err, InferenceError::Registry(_)),
+            "Expected InferenceError::Registry, got: {:?}",
+            err
+        );
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unknown model"), "Error: {}", msg);
+    }
+
+    #[test]
+    fn test_known_name_not_downloaded_returns_registry_not_found() {
+        // "miniLM" is in the catalog but not downloaded in the default dir.
+        // This MUST produce "not found locally", NOT "Unknown model".
+        let err = resolve_model("miniLM").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not found locally"),
+            "Expected 'not found locally' for known model, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_colon_name_not_downloaded_returns_registry_not_found() {
+        // "qwen3:8b" has colons but no '/' or '.gguf' → registry branch
+        let err = resolve_model("qwen3:8b").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("not found locally"),
+            "Expected 'not found locally' for known model, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_registry_name_resolves_when_file_exists() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        // Point STRATA_MODELS_DIR at a temp dir with the expected file
+        let dir = tempfile::tempdir().unwrap();
+        let original_env = std::env::var("STRATA_MODELS_DIR").ok();
+        std::env::set_var("STRATA_MODELS_DIR", dir.path());
+
+        // Find the expected filename for "miniLM" from the catalog
+        let expected_file = {
+            let entry = crate::registry::catalog::find_entry("miniLM").unwrap();
+            entry.variants[0].hf_file
+        };
+
+        // Place the file
+        std::fs::write(dir.path().join(expected_file), b"fake gguf").unwrap();
+
+        // Now resolve_model("miniLM") should succeed
+        let result = resolve_model("miniLM");
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let path = result.unwrap();
+        assert_eq!(path.file_name().unwrap(), expected_file);
+        assert!(path.exists());
+
+        // Restore env
+        match original_env {
+            Some(val) => std::env::set_var("STRATA_MODELS_DIR", val),
+            None => std::env::remove_var("STRATA_MODELS_DIR"),
+        }
+    }
+
+    #[test]
+    fn test_registry_colon_name_resolves_when_file_exists() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let original_env = std::env::var("STRATA_MODELS_DIR").ok();
+        std::env::set_var("STRATA_MODELS_DIR", dir.path());
+
+        let entry = crate::registry::catalog::find_entry("qwen3:8b").unwrap();
+        let expected_file = entry.variants.iter()
+            .find(|v| v.name == entry.default_quant)
+            .unwrap()
+            .hf_file;
+
+        std::fs::write(dir.path().join(expected_file), b"fake gguf").unwrap();
+
+        let result = resolve_model("qwen3:8b");
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result);
+        let path = result.unwrap();
+        assert_eq!(path.file_name().unwrap(), expected_file);
+
+        match original_env {
+            Some(val) => std::env::set_var("STRATA_MODELS_DIR", val),
+            None => std::env::remove_var("STRATA_MODELS_DIR"),
+        }
+    }
+
+    #[test]
+    fn test_alias_resolves_when_file_exists() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let original_env = std::env::var("STRATA_MODELS_DIR").ok();
+        std::env::set_var("STRATA_MODELS_DIR", dir.path());
+
+        // "tiny-llama" is an alias for "tinyllama"
+        let entry = crate::registry::catalog::find_entry("tinyllama").unwrap();
+        let expected_file = entry.variants[0].hf_file;
+        std::fs::write(dir.path().join(expected_file), b"fake").unwrap();
+
+        let result = resolve_model("tiny-llama");
+        assert!(result.is_ok(), "Expected Ok for alias, got: {:?}", result);
+        assert_eq!(result.unwrap().file_name().unwrap(), expected_file);
+
+        match original_env {
+            Some(val) => std::env::set_var("STRATA_MODELS_DIR", val),
+            None => std::env::remove_var("STRATA_MODELS_DIR"),
+        }
+    }
+
+    // ===== Edge cases =====
+
+    #[test]
+    fn test_empty_string_returns_registry_error() {
+        let err = resolve_model("").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+    }
+
+    #[test]
+    fn test_whitespace_only_returns_registry_error() {
+        let err = resolve_model("  ").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+    }
+
+    #[test]
+    fn test_dot_gguf_alone_is_file_path() {
+        // ".gguf" ends with .gguf → file-path branch (not registry)
+        let err = resolve_model(".gguf").unwrap_err();
+        assert!(matches!(err, InferenceError::Model(_)));
+    }
+}

--- a/src/engine/embed.rs
+++ b/src/engine/embed.rs
@@ -34,6 +34,17 @@ pub struct EmbeddingEngine {
 }
 
 impl EmbeddingEngine {
+    /// Load an embedding engine by model name from the registry.
+    ///
+    /// Resolves the name (e.g., `"miniLM"`) to a local GGUF file path
+    /// and auto-selects the best available compute backend.
+    pub fn from_registry(name: &str) -> Result<Self, InferenceError> {
+        let registry = crate::registry::ModelRegistry::new();
+        let path = registry.resolve(name)?;
+        let backend = crate::backend::select_backend();
+        Self::from_gguf(path, backend)
+    }
+
     /// Load an embedding engine from a GGUF file path.
     ///
     /// Auto-detects the model architecture, tokenizer type, and loads all

--- a/src/engine/generate.rs
+++ b/src/engine/generate.rs
@@ -164,6 +164,16 @@ pub struct GenerationEngine {
 }
 
 impl GenerationEngine {
+    /// Load a generation engine by model name from the registry.
+    ///
+    /// Resolves the name (e.g., `"qwen3:8b"`) to a local GGUF file path
+    /// and auto-selects the best available compute backend.
+    pub fn from_registry(name: &str) -> Result<Self, InferenceError> {
+        let registry = crate::registry::ModelRegistry::new();
+        let path = registry.resolve(name)?;
+        Self::from_gguf(path)
+    }
+
     /// Load a generation engine from a GGUF file, auto-selecting the best backend.
     ///
     /// Prefers Metal > CUDA > CPU.

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,4 +50,7 @@ pub enum InferenceError {
 
     #[error("Generation error: {0}")]
     Generation(String),
+
+    #[error("Registry error: {0}")]
+    Registry(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod tensor;
 pub mod backend;
 pub mod model;
 pub mod engine;
+pub mod registry;
 #[cfg(feature = "cli")]
 pub mod cli;
 
@@ -13,3 +14,4 @@ pub use engine::EmbeddingEngine;
 pub use engine::GenerationEngine;
 pub use tokenizer::create_tokenizer_from_gguf;
 pub use backend::select_backend;
+pub use registry::ModelRegistry;

--- a/src/registry/catalog.rs
+++ b/src/registry/catalog.rs
@@ -1,0 +1,458 @@
+//! Static catalog of known models with HuggingFace download metadata.
+
+use super::{CatalogEntry, ModelTask, QuantVariant};
+
+/// Static catalog of all known models.
+pub static CATALOG: &[CatalogEntry] = &[
+    // ===== Embedding Models =====
+    CatalogEntry {
+        name: "miniLM",
+        aliases: &["all-minilm"],
+        task: ModelTask::Embed,
+        hf_repo: "leliuga/all-MiniLM-L6-v2-GGUF",
+        default_quant: "f16",
+        variants: &[QuantVariant {
+            name: "f16",
+            hf_file: "all-MiniLM-L6-v2.F16.gguf",
+            size_bytes: 45_000_000,
+        }],
+        architecture: "bert",
+        embedding_dim: 384,
+    },
+    CatalogEntry {
+        name: "nomic-embed",
+        aliases: &["nomic", "nomic-embed-text"],
+        task: ModelTask::Embed,
+        hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
+        default_quant: "q8_0",
+        variants: &[QuantVariant {
+            name: "q8_0",
+            hf_file: "nomic-embed-text-v1.5.Q8_0.gguf",
+            size_bytes: 260_000_000,
+        }],
+        architecture: "nomic-bert",
+        embedding_dim: 768,
+    },
+    CatalogEntry {
+        name: "bge-m3",
+        aliases: &["bge"],
+        task: ModelTask::Embed,
+        hf_repo: "second-state/BGE-M3-GGUF",
+        default_quant: "q8_0",
+        variants: &[QuantVariant {
+            name: "q8_0",
+            hf_file: "bge-m3-Q8_0.gguf",
+            size_bytes: 1_200_000_000,
+        }],
+        architecture: "xlm-roberta",
+        embedding_dim: 1024,
+    },
+    CatalogEntry {
+        name: "gemma-embed",
+        aliases: &["embedding-gemma"],
+        task: ModelTask::Embed,
+        hf_repo: "lm-kit/embedding-gemma-300M-GGUF",
+        default_quant: "q8_0",
+        variants: &[QuantVariant {
+            name: "q8_0",
+            hf_file: "embedding-gemma-300M-Q8_0.gguf",
+            size_bytes: 320_000_000,
+        }],
+        architecture: "gemma3",
+        embedding_dim: 768,
+    },
+    // ===== Generation Models =====
+    CatalogEntry {
+        name: "gpt2",
+        aliases: &[],
+        task: ModelTask::Generate,
+        hf_repo: "ggml-org/models",
+        default_quant: "q8_0",
+        variants: &[QuantVariant {
+            name: "q8_0",
+            hf_file: "gpt-2-q8_0.gguf",
+            size_bytes: 170_000_000,
+        }],
+        architecture: "gpt2",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "tinyllama",
+        aliases: &["tiny-llama"],
+        task: ModelTask::Generate,
+        hf_repo: "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
+        default_quant: "q4_k_m",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
+                size_bytes: 670_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+                size_bytes: 1_100_000_000,
+            },
+        ],
+        architecture: "llama",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "qwen3:1.7b",
+        aliases: &["qwen3-1.7b"],
+        task: ModelTask::Generate,
+        hf_repo: "Qwen/Qwen3-1.7B-GGUF",
+        default_quant: "q8_0",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "Qwen3-1.7B-Q4_K_M.gguf",
+                size_bytes: 1_100_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "Qwen3-1.7B-Q8_0.gguf",
+                size_bytes: 2_000_000_000,
+            },
+        ],
+        architecture: "qwen3",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "gemma3:1b",
+        aliases: &["gemma3-1b", "gemma-3-1b"],
+        task: ModelTask::Generate,
+        hf_repo: "unsloth/gemma-3-1b-it-GGUF",
+        default_quant: "q4_k_m",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "gemma-3-1b-it-Q4_K_M.gguf",
+                size_bytes: 780_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "gemma-3-1b-it-Q8_0.gguf",
+                size_bytes: 1_400_000_000,
+            },
+        ],
+        architecture: "gemma3",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "phi3.5",
+        aliases: &["phi-3.5", "phi3.5-mini"],
+        task: ModelTask::Generate,
+        hf_repo: "bartowski/Phi-3.5-mini-instruct-GGUF",
+        default_quant: "q4_k_m",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "Phi-3.5-mini-instruct-Q4_K_M.gguf",
+                size_bytes: 2_400_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "Phi-3.5-mini-instruct-Q8_0.gguf",
+                size_bytes: 4_100_000_000,
+            },
+        ],
+        architecture: "phi3",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "llama3.1:8b",
+        aliases: &["llama3.1-8b", "llama-3.1-8b"],
+        task: ModelTask::Generate,
+        hf_repo: "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+        default_quant: "q4_k_m",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+                size_bytes: 4_600_000_000,
+            },
+            QuantVariant {
+                name: "q5_k_m",
+                hf_file: "Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf",
+                size_bytes: 5_300_000_000,
+            },
+            QuantVariant {
+                name: "q6_k",
+                hf_file: "Meta-Llama-3.1-8B-Instruct-Q6_K.gguf",
+                size_bytes: 6_100_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "Meta-Llama-3.1-8B-Instruct-Q8_0.gguf",
+                size_bytes: 8_100_000_000,
+            },
+        ],
+        architecture: "llama",
+        embedding_dim: 0,
+    },
+    CatalogEntry {
+        name: "qwen3:8b",
+        aliases: &["qwen3-8b"],
+        task: ModelTask::Generate,
+        hf_repo: "Qwen/Qwen3-8B-GGUF",
+        default_quant: "q4_k_m",
+        variants: &[
+            QuantVariant {
+                name: "q4_k_m",
+                hf_file: "Qwen3-8B-Q4_K_M.gguf",
+                size_bytes: 4_700_000_000,
+            },
+            QuantVariant {
+                name: "q5_k_m",
+                hf_file: "Qwen3-8B-Q5_K_M.gguf",
+                size_bytes: 5_400_000_000,
+            },
+            QuantVariant {
+                name: "q6_k",
+                hf_file: "Qwen3-8B-Q6_K.gguf",
+                size_bytes: 6_200_000_000,
+            },
+            QuantVariant {
+                name: "q8_0",
+                hf_file: "Qwen3-8B-Q8_0.gguf",
+                size_bytes: 8_200_000_000,
+            },
+        ],
+        architecture: "qwen3",
+        embedding_dim: 0,
+    },
+];
+
+/// Find a catalog entry by exact name or alias (case-insensitive).
+pub fn find_entry(name: &str) -> Option<&'static CatalogEntry> {
+    let lower = name.to_lowercase();
+    CATALOG.iter().find(|e| {
+        e.name.to_lowercase() == lower
+            || e.aliases.iter().any(|a| a.to_lowercase() == lower)
+    })
+}
+
+/// Find a catalog entry from colon-split parts.
+///
+/// Supports:
+/// - `["miniLM"]` → exact match
+/// - `["qwen3", "8b"]` → tries "qwen3:8b" as combined name
+/// - `["qwen3", "8b", "q6_k"]` → tries "qwen3:8b" as name, "q6_k" as quant
+pub fn find_entry_by_parts<'a>(parts: &[&'a str]) -> Option<(&'static CatalogEntry, Option<&'a str>)> {
+    match parts.len() {
+        0 => None,
+        1 => find_entry(parts[0]).map(|e| (e, None)),
+        2 => {
+            // Try "family:size" as combined name first
+            let combined = format!("{}:{}", parts[0], parts[1]);
+            if let Some(e) = find_entry(&combined) {
+                return Some((e, None));
+            }
+            // Fall back to treating parts[1] as a quant of a single-part name
+            find_entry(parts[0]).map(|e| (e, Some(parts[1])))
+        }
+        3 => {
+            let combined = format!("{}:{}", parts[0], parts[1]);
+            find_entry(&combined).map(|e| (e, Some(parts[2])))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_entry_exact() {
+        let entry = find_entry("miniLM").unwrap();
+        assert_eq!(entry.name, "miniLM");
+        assert_eq!(entry.task, ModelTask::Embed);
+        assert_eq!(entry.embedding_dim, 384);
+    }
+
+    #[test]
+    fn test_find_entry_case_insensitive() {
+        assert!(find_entry("MINILM").is_some());
+        assert!(find_entry("minilm").is_some());
+        assert!(find_entry("MiniLM").is_some());
+    }
+
+    #[test]
+    fn test_find_entry_alias() {
+        let entry = find_entry("nomic").unwrap();
+        assert_eq!(entry.name, "nomic-embed");
+    }
+
+    #[test]
+    fn test_find_entry_unknown() {
+        assert!(find_entry("unknown-model").is_none());
+    }
+
+    #[test]
+    fn test_find_entry_colon_name() {
+        let entry = find_entry("qwen3:8b").unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+        assert_eq!(entry.task, ModelTask::Generate);
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_single() {
+        let (entry, quant) = find_entry_by_parts(&["miniLM"]).unwrap();
+        assert_eq!(entry.name, "miniLM");
+        assert!(quant.is_none());
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_two_combined() {
+        let (entry, quant) = find_entry_by_parts(&["qwen3", "8b"]).unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+        assert!(quant.is_none());
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_two_with_quant_fallback() {
+        let (entry, quant) = find_entry_by_parts(&["tinyllama", "q8_0"]).unwrap();
+        assert_eq!(entry.name, "tinyllama");
+        assert_eq!(quant, Some("q8_0"));
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_three() {
+        let (entry, quant) = find_entry_by_parts(&["qwen3", "8b", "q6_k"]).unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+        assert_eq!(quant, Some("q6_k"));
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_empty() {
+        assert!(find_entry_by_parts(&[]).is_none());
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_too_many() {
+        assert!(find_entry_by_parts(&["a", "b", "c", "d"]).is_none());
+    }
+
+    #[test]
+    fn test_all_catalog_entries_have_valid_default_quant() {
+        for entry in CATALOG {
+            let found = entry.variants.iter().any(|v| v.name == entry.default_quant);
+            assert!(
+                found,
+                "Catalog entry '{}' has default_quant '{}' but no matching variant",
+                entry.name, entry.default_quant
+            );
+        }
+    }
+
+    #[test]
+    fn test_catalog_generation_models_have_zero_embedding_dim() {
+        for entry in CATALOG {
+            if entry.task == ModelTask::Generate {
+                assert_eq!(
+                    entry.embedding_dim, 0,
+                    "Generation model '{}' should have embedding_dim=0",
+                    entry.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_catalog_embedding_models_have_nonzero_embedding_dim() {
+        for entry in CATALOG {
+            if entry.task == ModelTask::Embed {
+                assert!(
+                    entry.embedding_dim > 0,
+                    "Embedding model '{}' should have embedding_dim > 0",
+                    entry.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_catalog_names_and_aliases_are_unique() {
+        // Collect all names and aliases into a flat list (lowercased)
+        let mut seen = std::collections::HashSet::new();
+        for entry in CATALOG {
+            let lower_name = entry.name.to_lowercase();
+            assert!(
+                seen.insert(lower_name.clone()),
+                "Duplicate catalog name: '{}'",
+                entry.name
+            );
+            for alias in entry.aliases {
+                let lower_alias = alias.to_lowercase();
+                assert!(
+                    seen.insert(lower_alias.clone()),
+                    "Duplicate alias '{}' in entry '{}'",
+                    alias, entry.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_catalog_entries_have_nonempty_variants() {
+        for entry in CATALOG {
+            assert!(
+                !entry.variants.is_empty(),
+                "Catalog entry '{}' has no variants",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_catalog_variant_filenames_end_with_gguf() {
+        for entry in CATALOG {
+            for variant in entry.variants {
+                assert!(
+                    variant.hf_file.ends_with(".gguf"),
+                    "Variant '{}' of '{}' doesn't end with .gguf: {}",
+                    variant.name, entry.name, variant.hf_file
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_find_entry_empty_string() {
+        assert!(find_entry("").is_none());
+    }
+
+    #[test]
+    fn test_find_entry_whitespace() {
+        assert!(find_entry(" miniLM ").is_none());
+        assert!(find_entry("  ").is_none());
+    }
+
+    #[test]
+    fn test_find_entry_case_insensitive_colon_name() {
+        // "QWEN3:8B" should match "qwen3:8b"
+        let entry = find_entry("QWEN3:8B").unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+    }
+
+    #[test]
+    fn test_find_entry_alias_case_insensitive() {
+        // Alias "tiny-llama" should match case-insensitively
+        let entry = find_entry("TINY-LLAMA").unwrap();
+        assert_eq!(entry.name, "tinyllama");
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_two_unknown_combined_unknown_single() {
+        // "unknown:thing" — neither "unknown:thing" nor "unknown" match
+        assert!(find_entry_by_parts(&["unknown", "thing"]).is_none());
+    }
+
+    #[test]
+    fn test_find_entry_by_parts_three_unknown_combined() {
+        // "unknown:thing:q8_0" — "unknown:thing" doesn't match
+        assert!(find_entry_by_parts(&["unknown", "thing", "q8_0"]).is_none());
+    }
+}

--- a/src/registry/download.rs
+++ b/src/registry/download.rs
@@ -1,0 +1,189 @@
+//! HuggingFace model download with progress reporting and lock files.
+//!
+//! Gated behind the `registry` feature flag.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use crate::error::InferenceError;
+
+/// Download a file from a HuggingFace repository to the local models directory.
+///
+/// The download uses a lock file to coordinate concurrent downloads and a
+/// temporary directory to avoid partial files.
+pub fn download_hf_file(
+    hf_repo: &str,
+    hf_file: &str,
+    models_dir: &Path,
+    progress: &dyn Fn(u64, u64),
+) -> Result<(), InferenceError> {
+    let dest = models_dir.join(hf_file);
+
+    // Already downloaded
+    if dest.exists() {
+        return Ok(());
+    }
+
+    // Ensure directories exist
+    fs::create_dir_all(models_dir).map_err(|e| {
+        InferenceError::Registry(format!("Failed to create models dir: {}", e))
+    })?;
+
+    let downloading_dir = models_dir.join(".downloading");
+    fs::create_dir_all(&downloading_dir).map_err(|e| {
+        InferenceError::Registry(format!("Failed to create .downloading dir: {}", e))
+    })?;
+
+    let lock_path = downloading_dir.join(format!("{}.lock", hf_file));
+    let temp_path = downloading_dir.join(hf_file);
+
+    // Check for lock file from another process
+    if lock_path.exists() {
+        let stale_threshold = Duration::from_secs(30 * 60); // 30 minutes
+        let lock_age = lock_path
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| SystemTime::now().duration_since(t).ok())
+            .unwrap_or(Duration::MAX);
+
+        if lock_age < stale_threshold {
+            // Another process is downloading — wait up to 10 minutes
+            let max_wait = Duration::from_secs(10 * 60);
+            let poll_interval = Duration::from_secs(5);
+            let start = std::time::Instant::now();
+
+            while lock_path.exists() && start.elapsed() < max_wait {
+                std::thread::sleep(poll_interval);
+            }
+
+            // Check if the file appeared
+            if dest.exists() {
+                return Ok(());
+            }
+            // If still locked after timeout, fall through and try ourselves
+        }
+
+        // Stale lock or timed out — remove and proceed
+        let _ = fs::remove_file(&lock_path);
+    }
+
+    // Write lock file with PID
+    let _lock_guard = LockGuard::new(&lock_path)?;
+
+    // Download
+    let url = format!(
+        "https://huggingface.co/{}/resolve/main/{}",
+        hf_repo, hf_file
+    );
+
+    let response = ureq::get(&url).call().map_err(|e| {
+        InferenceError::Registry(format!(
+            "Failed to download '{}' from HuggingFace: {}\n\n\
+             Please check your internet connection, or manually download and place the file at:\n  \
+             {}\n\n\
+             Download URL: {}",
+            hf_file, e,
+            dest.display(),
+            url
+        ))
+    })?;
+
+    let total_bytes = response
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    let mut reader = response.into_body().into_reader();
+    let mut file = fs::File::create(&temp_path).map_err(|e| {
+        InferenceError::Registry(format!("Failed to create temp file: {}", e))
+    })?;
+
+    let result = stream_to_file(&mut reader, &mut file, progress, total_bytes);
+
+    // Clean up temp file on any download error
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+        return result.map(|_| ());
+    }
+
+    let downloaded = result.unwrap();
+
+    // Verify size if content-length was provided
+    if total_bytes > 0 && downloaded != total_bytes {
+        let _ = fs::remove_file(&temp_path);
+        return Err(InferenceError::Registry(format!(
+            "Download size mismatch: expected {} bytes, got {}",
+            total_bytes, downloaded
+        )));
+    }
+
+    // Atomic-ish rename to final location
+    fs::rename(&temp_path, &dest).map_err(|e| {
+        InferenceError::Registry(format!(
+            "Failed to move downloaded file to {}: {}",
+            dest.display(),
+            e
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Stream from reader to file, returning total bytes written.
+fn stream_to_file(
+    reader: &mut dyn Read,
+    file: &mut fs::File,
+    progress: &dyn Fn(u64, u64),
+    total_bytes: u64,
+) -> Result<u64, InferenceError> {
+    let mut downloaded: u64 = 0;
+    let mut buf = vec![0u8; 64 * 1024]; // 64KB buffer
+
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| {
+            InferenceError::Registry(format!("Download read error: {}", e))
+        })?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n]).map_err(|e| {
+            InferenceError::Registry(format!("Failed to write temp file: {}", e))
+        })?;
+        downloaded += n as u64;
+        progress(downloaded, total_bytes);
+    }
+
+    file.flush().map_err(|e| {
+        InferenceError::Registry(format!("Failed to flush temp file: {}", e))
+    })?;
+
+    Ok(downloaded)
+}
+
+/// RAII guard that creates a lock file on construction and removes it on drop.
+struct LockGuard {
+    path: std::path::PathBuf,
+}
+
+impl LockGuard {
+    fn new(path: &Path) -> Result<Self, InferenceError> {
+        let pid = std::process::id();
+        fs::write(path, format!("{}", pid)).map_err(|e| {
+            InferenceError::Registry(format!("Failed to write lock file: {}", e))
+        })?;
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/src/registry/hardware.rs
+++ b/src/registry/hardware.rs
@@ -1,0 +1,81 @@
+//! Hardware detection for automatic backend selection.
+
+/// Information about available compute hardware.
+#[derive(Debug, Clone)]
+pub struct HardwareInfo {
+    pub cuda_available: bool,
+    pub metal_available: bool,
+    pub cpu_available: bool,
+    pub recommended_backend: String,
+}
+
+impl HardwareInfo {
+    /// Detect available hardware backends.
+    ///
+    /// Probes CUDA > Metal > CPU (same priority as `select_backend`).
+    /// Never panics — if probing fails, that backend is marked unavailable.
+    pub fn detect() -> Self {
+        let cuda_available = Self::probe_cuda();
+        let metal_available = Self::probe_metal();
+
+        let recommended_backend = if cuda_available {
+            "cuda"
+        } else if metal_available {
+            "metal"
+        } else {
+            "cpu"
+        }
+        .to_string();
+
+        Self {
+            cuda_available,
+            metal_available,
+            cpu_available: true,
+            recommended_backend,
+        }
+    }
+
+    fn probe_cuda() -> bool {
+        #[cfg(feature = "cuda")]
+        {
+            crate::backend::cuda::CudaBackend::try_new().is_ok()
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            false
+        }
+    }
+
+    fn probe_metal() -> bool {
+        #[cfg(all(feature = "metal", target_os = "macos"))]
+        {
+            crate::backend::metal::MetalBackend::try_new().is_ok()
+        }
+        #[cfg(not(all(feature = "metal", target_os = "macos")))]
+        {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_does_not_panic() {
+        let info = HardwareInfo::detect();
+        assert!(info.cpu_available);
+        assert!(!info.recommended_backend.is_empty());
+    }
+
+    #[test]
+    fn test_recommended_backend_is_valid() {
+        let info = HardwareInfo::detect();
+        assert!(
+            ["cuda", "metal", "cpu"].contains(&info.recommended_backend.as_str()),
+            "Unexpected backend: {}",
+            info.recommended_backend
+        );
+    }
+}

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -257,7 +257,7 @@ impl Default for ModelRegistry {
 }
 
 /// Format bytes as a human-readable string (e.g., "4.7 GB").
-fn format_size(bytes: u64) -> String {
+pub fn format_size(bytes: u64) -> String {
     const GB: u64 = 1_000_000_000;
     const MB: u64 = 1_000_000;
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,0 +1,710 @@
+//! Model registry for resolving friendly model names to local GGUF file paths.
+//!
+//! The registry maps names like `"miniLM"` or `"qwen3:8b"` to HuggingFace GGUF
+//! files, manages a local download cache, and provides offline-friendly error
+//! messages when models aren't available.
+//!
+//! # Name Format
+//!
+//! Names follow `name`, `name:size`, or `name:size:quant`:
+//! - `"miniLM"` → catalog entry "miniLM", default quant
+//! - `"qwen3:8b"` → catalog entry "qwen3:8b", default quant (q4_k_m)
+//! - `"qwen3:8b:q6_k"` → catalog entry "qwen3:8b", variant q6_k
+//!
+//! # Models Directory
+//!
+//! Models are stored in (in priority order):
+//! 1. `STRATA_MODELS_DIR` environment variable (if set)
+//! 2. `~/.strata/models/` (default)
+
+pub mod catalog;
+#[cfg(feature = "registry")]
+pub mod download;
+pub mod hardware;
+
+use std::path::{Path, PathBuf};
+
+use crate::error::InferenceError;
+
+/// What a model is designed for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelTask {
+    Embed,
+    Generate,
+}
+
+/// A quantization variant of a catalog model.
+#[derive(Debug, Clone)]
+pub struct QuantVariant {
+    /// Quant name: "q4_k_m", "q8_0", "f16"
+    pub name: &'static str,
+    /// Filename on HuggingFace: "Qwen3-8B-Q4_K_M.gguf"
+    pub hf_file: &'static str,
+    /// Approximate file size in bytes.
+    pub size_bytes: u64,
+}
+
+/// A model entry in the static catalog.
+#[derive(Debug, Clone)]
+pub struct CatalogEntry {
+    /// Primary name: "qwen3:8b"
+    pub name: &'static str,
+    /// Alternative names: ["qwen3-8b"]
+    pub aliases: &'static [&'static str],
+    /// Task type.
+    pub task: ModelTask,
+    /// HuggingFace repository: "Qwen/Qwen3-8B-GGUF"
+    pub hf_repo: &'static str,
+    /// Default quant variant: "q4_k_m"
+    pub default_quant: &'static str,
+    /// Available quant variants.
+    pub variants: &'static [QuantVariant],
+    /// Model architecture: "qwen3", "llama", "bert"
+    pub architecture: &'static str,
+    /// Embedding dimension (0 for generation models).
+    pub embedding_dim: usize,
+}
+
+/// Information about a resolved model.
+#[derive(Debug, Clone)]
+pub struct ModelInfo {
+    pub name: String,
+    pub task: ModelTask,
+    pub architecture: String,
+    pub default_quant: String,
+    pub embedding_dim: usize,
+    pub is_local: bool,
+    pub local_path: Option<PathBuf>,
+    pub size_bytes: u64,
+    pub hf_repo: String,
+}
+
+/// Model registry for resolving names to local GGUF file paths.
+pub struct ModelRegistry {
+    models_dir: PathBuf,
+}
+
+impl ModelRegistry {
+    /// Create a registry using the default models directory.
+    ///
+    /// Resolution order:
+    /// 1. `STRATA_MODELS_DIR` environment variable
+    /// 2. `~/.strata/models/`
+    pub fn new() -> Self {
+        let models_dir = if let Ok(dir) = std::env::var("STRATA_MODELS_DIR") {
+            PathBuf::from(dir)
+        } else {
+            dirs_default_models()
+        };
+        Self { models_dir }
+    }
+
+    /// Create a registry with a custom models directory.
+    pub fn with_dir(dir: PathBuf) -> Self {
+        Self { models_dir: dir }
+    }
+
+    /// The directory where models are stored.
+    pub fn models_dir(&self) -> &Path {
+        &self.models_dir
+    }
+
+    /// List all models in the catalog with their local availability.
+    pub fn list_available(&self) -> Vec<ModelInfo> {
+        catalog::CATALOG
+            .iter()
+            .map(|entry| self.entry_to_info(entry, entry.default_quant))
+            .collect()
+    }
+
+    /// List only models that have at least one variant downloaded locally.
+    pub fn list_local(&self) -> Vec<ModelInfo> {
+        catalog::CATALOG
+            .iter()
+            .filter_map(|entry| {
+                // Find the first locally-present variant
+                let local_variant = entry.variants.iter().find(|v| {
+                    self.models_dir.join(v.hf_file).exists()
+                });
+                local_variant.map(|v| self.entry_to_info(entry, v.name))
+            })
+            .collect()
+    }
+
+    /// Resolve a model name to a local file path.
+    ///
+    /// Returns `Ok(path)` if the model file exists locally.
+    /// Returns `Err` with a helpful message including download instructions
+    /// if the model is not available locally.
+    pub fn resolve(&self, name: &str) -> Result<PathBuf, InferenceError> {
+        let (entry, quant) = self.parse_name(name)?;
+        let quant_name = quant.unwrap_or(entry.default_quant);
+
+        let variant = entry
+            .variants
+            .iter()
+            .find(|v| v.name.eq_ignore_ascii_case(quant_name))
+            .ok_or_else(|| {
+                let available: Vec<&str> = entry.variants.iter().map(|v| v.name).collect();
+                InferenceError::Registry(format!(
+                    "Unknown quant '{}' for model '{}'. Available: {}",
+                    quant_name,
+                    entry.name,
+                    available.join(", ")
+                ))
+            })?;
+
+        let path = self.models_dir.join(variant.hf_file);
+
+        if path.exists() {
+            return Ok(path);
+        }
+
+        let size_display = format_size(variant.size_bytes);
+
+        Err(InferenceError::Registry(format!(
+            "Model '{}' not found locally.\n\n\
+             To download it (requires internet):\n  \
+             strata models pull {}\n\n\
+             Or manually place the GGUF file at:\n  \
+             {}\n\n\
+             Expected file: {} ({})\n\
+             Source: https://huggingface.co/{}",
+            name,
+            name,
+            path.display(),
+            variant.hf_file,
+            size_display,
+            entry.hf_repo
+        )))
+    }
+
+    /// Download a model and return its local path.
+    #[cfg(feature = "registry")]
+    pub fn pull(&self, name: &str) -> Result<PathBuf, InferenceError> {
+        self.pull_with_progress(name, |_, _| {})
+    }
+
+    /// Download a model with a progress callback and return its local path.
+    ///
+    /// The callback receives `(bytes_downloaded, total_bytes)`.
+    #[cfg(feature = "registry")]
+    pub fn pull_with_progress(
+        &self,
+        name: &str,
+        cb: impl Fn(u64, u64),
+    ) -> Result<PathBuf, InferenceError> {
+        let (entry, quant) = self.parse_name(name)?;
+        let quant_name = quant.unwrap_or(entry.default_quant);
+
+        let variant = entry
+            .variants
+            .iter()
+            .find(|v| v.name.eq_ignore_ascii_case(quant_name))
+            .ok_or_else(|| {
+                InferenceError::Registry(format!(
+                    "Unknown quant '{}' for model '{}'",
+                    quant_name, entry.name
+                ))
+            })?;
+
+        download::download_hf_file(entry.hf_repo, variant.hf_file, &self.models_dir, &cb)?;
+
+        Ok(self.models_dir.join(variant.hf_file))
+    }
+
+    /// Parse a model name string into a catalog entry and optional quant override.
+    fn parse_name<'a>(&self, name: &'a str) -> Result<(&'static CatalogEntry, Option<&'a str>), InferenceError> {
+        let parts: Vec<&str> = name.split(':').collect();
+
+        catalog::find_entry_by_parts(&parts).ok_or_else(|| {
+            InferenceError::Registry(format!(
+                "Unknown model '{}'. Run `strata models list` to see available models.",
+                name
+            ))
+        })
+    }
+
+    /// Convert a catalog entry to a ModelInfo with local availability check.
+    fn entry_to_info(&self, entry: &CatalogEntry, quant_name: &str) -> ModelInfo {
+        let variant = entry
+            .variants
+            .iter()
+            .find(|v| v.name == quant_name)
+            .unwrap_or(&entry.variants[0]);
+
+        let path = self.models_dir.join(variant.hf_file);
+        let is_local = path.exists();
+
+        ModelInfo {
+            name: entry.name.to_string(),
+            task: entry.task,
+            architecture: entry.architecture.to_string(),
+            default_quant: entry.default_quant.to_string(),
+            embedding_dim: entry.embedding_dim,
+            is_local,
+            local_path: if is_local { Some(path) } else { None },
+            size_bytes: variant.size_bytes,
+            hf_repo: entry.hf_repo.to_string(),
+        }
+    }
+}
+
+impl Default for ModelRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Format bytes as a human-readable string (e.g., "4.7 GB").
+fn format_size(bytes: u64) -> String {
+    const GB: u64 = 1_000_000_000;
+    const MB: u64 = 1_000_000;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.0} MB", bytes as f64 / MB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}
+
+/// Default models directory: `~/.strata/models/`
+fn dirs_default_models() -> PathBuf {
+    if let Some(home) = home_dir() {
+        home.join(".strata").join("models")
+    } else {
+        PathBuf::from(".strata/models")
+    }
+}
+
+/// Get the user's home directory.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mutex to serialize tests that mutate STRATA_MODELS_DIR env var.
+    // Required because Rust runs tests in parallel and env vars are global.
+    use std::sync::Mutex;
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn test_registry() -> (tempfile::TempDir, ModelRegistry) {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = ModelRegistry::with_dir(dir.path().to_path_buf());
+        (dir, registry)
+    }
+
+    // ===== resolve() tests =====
+
+    #[test]
+    fn test_resolve_not_found_gives_helpful_error() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve("miniLM").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("not found locally"), "Error: {}", msg);
+        assert!(msg.contains("strata models pull miniLM"), "Error: {}", msg);
+        assert!(msg.contains(".gguf"), "Error: {}", msg);
+        assert!(msg.contains("huggingface.co"), "Error: {}", msg);
+        // Error should contain the model's expected file size
+        assert!(msg.contains("MB") || msg.contains("GB"), "Should show size: {}", msg);
+    }
+
+    #[test]
+    fn test_resolve_found_when_file_exists() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("miniLM").unwrap();
+        let variant = &entry.variants[0];
+        std::fs::write(dir.path().join(variant.hf_file), b"fake gguf").unwrap();
+
+        let path = registry.resolve("miniLM").unwrap();
+        assert!(path.exists());
+        assert_eq!(path.file_name().unwrap(), variant.hf_file);
+    }
+
+    #[test]
+    fn test_resolve_with_quant_override() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("tinyllama").unwrap();
+        let q8_variant = entry.variants.iter().find(|v| v.name == "q8_0").unwrap();
+        std::fs::write(dir.path().join(q8_variant.hf_file), b"fake gguf").unwrap();
+
+        let path = registry.resolve("tinyllama:q8_0").unwrap();
+        assert!(path.exists());
+        assert_eq!(path.file_name().unwrap(), q8_variant.hf_file);
+    }
+
+    #[test]
+    fn test_resolve_case_insensitive_quant() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("tinyllama").unwrap();
+        let q8_variant = entry.variants.iter().find(|v| v.name == "q8_0").unwrap();
+        std::fs::write(dir.path().join(q8_variant.hf_file), b"fake").unwrap();
+
+        // Uppercase quant should still resolve
+        let path = registry.resolve("tinyllama:Q8_0").unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_resolve_via_alias() {
+        let (dir, registry) = test_registry();
+
+        // "nomic" is an alias for "nomic-embed"
+        let entry = catalog::find_entry("nomic-embed").unwrap();
+        let variant = &entry.variants[0];
+        std::fs::write(dir.path().join(variant.hf_file), b"fake").unwrap();
+
+        let path = registry.resolve("nomic").unwrap();
+        assert!(path.exists());
+        assert_eq!(path.file_name().unwrap(), variant.hf_file);
+    }
+
+    #[test]
+    fn test_resolve_via_alias_case_insensitive() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("tinyllama").unwrap();
+        let variant = &entry.variants[0];
+        std::fs::write(dir.path().join(variant.hf_file), b"fake").unwrap();
+
+        // "TINY-LLAMA" is alias for "tinyllama", case-insensitive
+        let path = registry.resolve("TINY-LLAMA").unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_resolve_unknown_quant_lists_available() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve("tinyllama:iq2_xs").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unknown quant"), "Error: {}", msg);
+        // Should list both available quants
+        assert!(msg.contains("q4_k_m"), "Should list q4_k_m: {}", msg);
+        assert!(msg.contains("q8_0"), "Should list q8_0: {}", msg);
+    }
+
+    #[test]
+    fn test_resolve_unknown_model_gives_error() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve("nonexistent-model").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unknown model"), "Error: {}", msg);
+    }
+
+    #[test]
+    fn test_resolve_empty_string() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve("").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unknown model"), "Error: {}", msg);
+    }
+
+    #[test]
+    fn test_resolve_whitespace_only() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve("  ").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("Unknown model"), "Error: {}", msg);
+    }
+
+    #[test]
+    fn test_resolve_trailing_colon() {
+        let (_dir, registry) = test_registry();
+
+        // "qwen3:" splits to ["qwen3", ""] — "qwen3:" isn't a name, and
+        // "qwen3" alone isn't either (only "qwen3:1.7b" and "qwen3:8b" exist).
+        let err = registry.resolve("qwen3:").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+    }
+
+    #[test]
+    fn test_resolve_leading_colon() {
+        let (_dir, registry) = test_registry();
+
+        let err = registry.resolve(":miniLM").unwrap_err();
+        assert!(matches!(err, InferenceError::Registry(_)));
+    }
+
+    #[test]
+    fn test_resolve_colon_name_with_quant() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("qwen3:8b").unwrap();
+        let q6k_variant = entry.variants.iter().find(|v| v.name == "q6_k").unwrap();
+        std::fs::write(dir.path().join(q6k_variant.hf_file), b"fake").unwrap();
+
+        let path = registry.resolve("qwen3:8b:q6_k").unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_resolve_default_quant_not_found_but_other_exists() {
+        let (dir, registry) = test_registry();
+
+        // Place q8_0 but NOT q4_k_m (the default) for tinyllama
+        let entry = catalog::find_entry("tinyllama").unwrap();
+        let q8_variant = entry.variants.iter().find(|v| v.name == "q8_0").unwrap();
+        std::fs::write(dir.path().join(q8_variant.hf_file), b"fake").unwrap();
+
+        // resolve("tinyllama") without quant override → looks for default (q4_k_m) → not found
+        let err = registry.resolve("tinyllama").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("not found locally"), "Should fail for default quant: {}", msg);
+
+        // But explicit q8_0 should work
+        let path = registry.resolve("tinyllama:q8_0").unwrap();
+        assert!(path.exists());
+    }
+
+    // ===== list_available() / list_local() tests =====
+
+    #[test]
+    fn test_list_available_returns_all() {
+        let (_dir, registry) = test_registry();
+
+        let available = registry.list_available();
+        assert_eq!(available.len(), catalog::CATALOG.len());
+        assert!(available.iter().all(|m| !m.is_local));
+    }
+
+    #[test]
+    fn test_list_local_empty_dir() {
+        let (_dir, registry) = test_registry();
+
+        let local = registry.list_local();
+        assert!(local.is_empty());
+    }
+
+    #[test]
+    fn test_list_local_with_default_variant() {
+        let (dir, registry) = test_registry();
+
+        let entry = catalog::find_entry("miniLM").unwrap();
+        let variant = &entry.variants[0];
+        std::fs::write(dir.path().join(variant.hf_file), b"fake").unwrap();
+
+        let local = registry.list_local();
+        assert_eq!(local.len(), 1);
+        assert_eq!(local[0].name, "miniLM");
+        assert!(local[0].is_local);
+        assert!(local[0].local_path.is_some());
+    }
+
+    #[test]
+    fn test_list_local_finds_non_default_variant() {
+        let (dir, registry) = test_registry();
+
+        // Place q8_0 (non-default) for tinyllama — list_local should still find it
+        let entry = catalog::find_entry("tinyllama").unwrap();
+        assert_eq!(entry.default_quant, "q4_k_m"); // confirm q8_0 is non-default
+        let q8_variant = entry.variants.iter().find(|v| v.name == "q8_0").unwrap();
+        std::fs::write(dir.path().join(q8_variant.hf_file), b"fake").unwrap();
+
+        let local = registry.list_local();
+        assert_eq!(local.len(), 1, "Should find tinyllama via non-default q8_0 variant");
+        assert_eq!(local[0].name, "tinyllama");
+        assert!(local[0].is_local);
+    }
+
+    #[test]
+    fn test_list_local_multiple_models() {
+        let (dir, registry) = test_registry();
+
+        // Place files for two different models
+        let entry1 = catalog::find_entry("miniLM").unwrap();
+        std::fs::write(dir.path().join(entry1.variants[0].hf_file), b"fake").unwrap();
+
+        let entry2 = catalog::find_entry("gpt2").unwrap();
+        std::fs::write(dir.path().join(entry2.variants[0].hf_file), b"fake").unwrap();
+
+        let local = registry.list_local();
+        assert_eq!(local.len(), 2);
+        let names: Vec<&str> = local.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"miniLM"));
+        assert!(names.contains(&"gpt2"));
+    }
+
+    #[test]
+    fn test_list_local_ignores_unrelated_files() {
+        let (dir, registry) = test_registry();
+
+        // Place a random .gguf file that doesn't match any catalog entry
+        std::fs::write(dir.path().join("random-model.gguf"), b"fake").unwrap();
+
+        let local = registry.list_local();
+        assert!(local.is_empty(), "Should not match random files");
+    }
+
+    // ===== parse_name() tests =====
+
+    #[test]
+    fn test_parse_name_single_part() {
+        let (_dir, registry) = test_registry();
+
+        let (entry, quant) = registry.parse_name("miniLM").unwrap();
+        assert_eq!(entry.name, "miniLM");
+        assert!(quant.is_none());
+    }
+
+    #[test]
+    fn test_parse_name_two_part_combined() {
+        let (_dir, registry) = test_registry();
+
+        let (entry, quant) = registry.parse_name("qwen3:8b").unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+        assert!(quant.is_none());
+    }
+
+    #[test]
+    fn test_parse_name_three_part() {
+        let (_dir, registry) = test_registry();
+
+        let (entry, quant) = registry.parse_name("qwen3:8b:q6_k").unwrap();
+        assert_eq!(entry.name, "qwen3:8b");
+        assert_eq!(quant, Some("q6_k"));
+    }
+
+    #[test]
+    fn test_parse_name_four_parts_fails() {
+        let (_dir, registry) = test_registry();
+        assert!(registry.parse_name("a:b:c:d").is_err());
+    }
+
+    // ===== ModelInfo fields tests =====
+
+    #[test]
+    fn test_model_info_embed_fields() {
+        let (_dir, registry) = test_registry();
+
+        let available = registry.list_available();
+        let minilm = available.iter().find(|m| m.name == "miniLM").unwrap();
+        assert_eq!(minilm.task, ModelTask::Embed);
+        assert_eq!(minilm.embedding_dim, 384);
+        assert_eq!(minilm.architecture, "bert");
+        assert!(!minilm.is_local);
+        assert!(minilm.local_path.is_none());
+        assert!(minilm.size_bytes > 0);
+        assert!(!minilm.hf_repo.is_empty());
+    }
+
+    #[test]
+    fn test_model_info_generate_fields() {
+        let (_dir, registry) = test_registry();
+
+        let available = registry.list_available();
+        let qwen = available.iter().find(|m| m.name == "qwen3:8b").unwrap();
+        assert_eq!(qwen.task, ModelTask::Generate);
+        assert_eq!(qwen.embedding_dim, 0);
+        assert_eq!(qwen.architecture, "qwen3");
+    }
+
+    // ===== ModelRegistry construction tests =====
+
+    #[test]
+    fn test_models_dir_accessor() {
+        let (dir, registry) = test_registry();
+        assert_eq!(registry.models_dir(), dir.path());
+    }
+
+    #[test]
+    fn test_env_var_override() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let key = "STRATA_MODELS_DIR";
+        let original = std::env::var(key).ok();
+
+        let unique_path = format!("/tmp/test-strata-models-{}", std::process::id());
+        std::env::set_var(key, &unique_path);
+        let registry = ModelRegistry::new();
+        assert_eq!(
+            registry.models_dir(),
+            Path::new(&unique_path)
+        );
+
+        // Restore
+        match original {
+            Some(val) => std::env::set_var(key, val),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn test_default_models_dir() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let key = "STRATA_MODELS_DIR";
+        let original = std::env::var(key).ok();
+        std::env::remove_var(key);
+
+        let registry = ModelRegistry::new();
+        let dir = registry.models_dir();
+        assert!(
+            dir.ends_with(".strata/models"),
+            "Default dir should end with .strata/models, got: {}",
+            dir.display()
+        );
+
+        // Restore
+        match original {
+            Some(val) => std::env::set_var(key, val),
+            None => {}, // already removed
+        }
+    }
+
+    // ===== format_size() tests =====
+
+    #[test]
+    fn test_format_size_bytes() {
+        assert_eq!(format_size(0), "0 bytes");
+        assert_eq!(format_size(1), "1 bytes");
+        assert_eq!(format_size(500), "500 bytes");
+        assert_eq!(format_size(999_999), "999999 bytes");
+    }
+
+    #[test]
+    fn test_format_size_megabytes() {
+        assert_eq!(format_size(1_000_000), "1 MB");
+        assert_eq!(format_size(45_000_000), "45 MB");
+        assert_eq!(format_size(999_999_999), "1000 MB");
+    }
+
+    #[test]
+    fn test_format_size_gigabytes() {
+        assert_eq!(format_size(1_000_000_000), "1.0 GB");
+        assert_eq!(format_size(4_700_000_000), "4.7 GB");
+        assert_eq!(format_size(10_500_000_000), "10.5 GB");
+    }
+
+    // ===== Integration test (requires network) =====
+
+    #[cfg(feature = "registry")]
+    #[test]
+    #[ignore]
+    fn test_pull_gpt2() {
+        let (dir, registry) = test_registry();
+
+        // First pull
+        let path = registry.pull("gpt2").unwrap();
+        assert!(path.exists());
+        let size = path.metadata().unwrap().len();
+        assert!(size > 1_000_000, "GPT-2 should be >1MB, got {} bytes", size);
+
+        // Second pull should be idempotent (no re-download)
+        let path2 = registry.pull("gpt2").unwrap();
+        assert_eq!(path, path2);
+        assert_eq!(path2.metadata().unwrap().len(), size);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a model registry that maps friendly names (e.g., `"qwen3:8b"`, `"miniLM"`) to local GGUF files with a static catalog of known models and HuggingFace download metadata
- Updates all CLI binaries (`strata-generate`, `strata-embed`, `strata-tokenize`, `strata-metal-generate`) so `-m/--model` accepts both file paths and registry names seamlessly
- Adds `strata-models` CLI binary with `list`, `pull`, and `path` subcommands for managing downloaded models

## Details

**Model resolver** (`src/cli/model.rs`): Heuristic detects file paths (contains `/`, `\`, or ends with `.gguf` case-insensitive) vs registry names. File paths are validated for existence; bare names go through the registry. 17 unit tests cover both branches, edge cases, error variants, and happy-path registry resolution.

**Registry** (`src/registry/`): Static catalog of 10 models (4 embedding, 6 generation) with HuggingFace repos, quant variants, and size metadata. Supports `name`, `name:size`, and `name:size:quant` formats with case-insensitive matching and aliases. Download gated behind `registry` feature flag with lock files and progress callbacks.

**Backward compatible**: Existing scripts using file paths (e.g., `-m ~/models/model.gguf`) continue to work unchanged.

## Test plan

- [x] All 790 existing unit tests pass
- [x] 17 new `cli::model` tests pass (including registry happy-path with `STRATA_MODELS_DIR`)
- [x] All 5 binaries compile (`cargo build --features cli` and `--features cli,metal`)
- [ ] Manual smoke test: `strata-generate -m ~/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf -p "Hello" -n 10 --temp 0`
- [ ] Manual smoke test: `strata-models list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)